### PR TITLE
fix: add 7 missing MODEL_TO_FAMILY mappings

### DIFF
--- a/utils/insight_ledger.py
+++ b/utils/insight_ledger.py
@@ -77,8 +77,11 @@ MODEL_TO_FAMILY = {
     "histgb_clf": MODEL_FAMILY_TREE,
     "nn": MODEL_FAMILY_NEURAL,
     "knn_reg": MODEL_FAMILY_DISTANCE, "knn_clf": MODEL_FAMILY_DISTANCE,
-    "svm": MODEL_FAMILY_MARGIN,
+    "svr": MODEL_FAMILY_MARGIN, "svc": MODEL_FAMILY_MARGIN,
     "naive_bayes": MODEL_FAMILY_PROBABILISTIC, "lda": MODEL_FAMILY_PROBABILISTIC,
+    "gaussian_nb": MODEL_FAMILY_PROBABILISTIC,
+    "xgb_reg": MODEL_FAMILY_TREE, "xgb_clf": MODEL_FAMILY_TREE,
+    "lgbm_reg": MODEL_FAMILY_TREE, "lgbm_clf": MODEL_FAMILY_TREE,
 }
 
 # Human-readable model names for reports and narrative
@@ -97,9 +100,15 @@ MODEL_DISPLAY_NAMES = {
     "nn": "Neural Network (MLP)",
     "knn_reg": "k-Nearest Neighbors (Regressor)",
     "knn_clf": "k-Nearest Neighbors (Classifier)",
-    "svm": "Support Vector Machine",
+    "svr": "Support Vector Regressor",
+    "svc": "Support Vector Classifier",
     "naive_bayes": "Naïve Bayes",
+    "gaussian_nb": "Gaussian Naïve Bayes",
     "lda": "Linear Discriminant Analysis",
+    "xgb_reg": "XGBoost (Regressor)",
+    "xgb_clf": "XGBoost (Classifier)",
+    "lgbm_reg": "LightGBM (Regressor)",
+    "lgbm_clf": "LightGBM (Classifier)",
 }
 
 


### PR DESCRIPTION
## Summary

Adds 7 missing model keys to `MODEL_TO_FAMILY` and `MODEL_DISPLAY_NAMES` in `utils/insight_ledger.py`. Removes stale `svm` key, replaced with correct `svr`/`svc` split.

## Changes

- `svr`, `svc` → `MODEL_FAMILY_MARGIN`
- `gaussian_nb` → `MODEL_FAMILY_PROBABILISTIC`
- `xgb_reg`, `xgb_clf`, `lgbm_reg`, `lgbm_clf` → `MODEL_FAMILY_TREE`
- Display names added for all 7 new keys

## Testing

All 111 tests pass.

Fixes #51