### PR TITLE
fix: remove deprecated use_container_width and utcnow calls

### DIFF
--- a/pages/01_Upload_and_Audit.py
+++ b/pages/01_Upload_and_Audit.py
@@ -1410,7 +1410,7 @@ with _card_cols[0]:
     _pred_bg = "#f0f2ff" if _pred_selected else "#ffffff"
     _pred_check = "<div style='color:#667eea; font-weight:600; margin-top:4px;'>✓ Selected</div>" if _pred_selected else "<div style='margin-top:4px;'>&nbsp;</div>"
     st.markdown(f"<div style='border:2px solid {_pred_border}; border-radius:12px; padding:20px; background:{_pred_bg}; text-align:center; margin-bottom:8px;'><div style='font-size:2em;'>📊</div><div style='font-weight:600; font-size:1.1em;'>Prediction</div><div style='color:#64748b; font-size:0.85em;'>Build &amp; compare ML models</div>{_pred_check}</div>", unsafe_allow_html=True)
-    if st.button("Select Prediction", key="btn_prediction", type="primary" if _pred_selected else "secondary", use_container_width=True):
+    if st.button("Select Prediction", key="btn_prediction", type="primary" if _pred_selected else "secondary"):
         st.session_state.task_mode = 'prediction'
         st.rerun()
 
@@ -1420,7 +1420,7 @@ with _card_cols[1]:
     _hyp_bg = "#f0f2ff" if _hyp_selected else "#ffffff"
     _hyp_check = "<div style='color:#667eea; font-weight:600; margin-top:4px;'>✓ Selected</div>" if _hyp_selected else "<div style='margin-top:4px;'>&nbsp;</div>"
     st.markdown(f"<div style='border:2px solid {_hyp_border}; border-radius:12px; padding:20px; background:{_hyp_bg}; text-align:center; margin-bottom:8px;'><div style='font-size:2em;'>🔬</div><div style='font-weight:600; font-size:1.1em;'>Hypothesis Testing</div><div style='color:#64748b; font-size:0.85em;'>Statistical tests without ML</div>{_hyp_check}</div>", unsafe_allow_html=True)
-    if st.button("Select Hypothesis Testing", key="btn_hypothesis", type="primary" if _hyp_selected else "secondary", use_container_width=True):
+    if st.button("Select Hypothesis Testing", key="btn_hypothesis", type="primary" if _hyp_selected else "secondary"):
         st.session_state.task_mode = 'hypothesis_testing'
         st.rerun()
 

--- a/pages/02_EDA.py
+++ b/pages/02_EDA.py
@@ -533,7 +533,7 @@ with st.expander("🔍 Column Inspector", expanded=False):
                 showlegend=False, margin=dict(l=0, r=0, t=10, b=0),
                 xaxis_title="", yaxis_title="",
             )
-            st.plotly_chart(fig, use_container_width=True)
+            st.plotly_chart(fig)
 
             desc = col_data.describe()
             d1, d2, d3, d4 = st.columns(4)
@@ -549,7 +549,7 @@ with st.expander("🔍 Column Inspector", expanded=False):
                 showlegend=False, margin=dict(l=0, r=0, t=10, b=0),
                 xaxis_title="", yaxis_title="Count",
             )
-            st.plotly_chart(fig, use_container_width=True)
+            st.plotly_chart(fig)
 
         # Show insights for this column
         col_insights = ledger.get_for_features([inspect_col])
@@ -575,7 +575,7 @@ if _has_target:
     with tc1:
         fig_hist = px.histogram(df, x=target_col, nbins=30, title=f"Distribution of {target_col}")
         fig_hist.update_layout(template="plotly_white", height=350)
-        st.plotly_chart(fig_hist, use_container_width=True)
+        st.plotly_chart(fig_hist)
     with tc2:
         if task_type_final == "classification":
             class_counts = df[target_col].value_counts().sort_index()
@@ -585,14 +585,14 @@ if _has_target:
                 labels={"x": "Class", "y": "Count"},
             )
             fig_bar.update_layout(template="plotly_white", height=350)
-            st.plotly_chart(fig_bar, use_container_width=True)
+            st.plotly_chart(fig_bar)
             imbalance = class_counts.min() / class_counts.max()
             if imbalance < 0.35:
                 st.caption(f"⚠️ Class imbalance: {imbalance:.2f} ratio. Stratified sampling recommended.")
         else:
             fig_box = px.box(df, y=target_col, title=f"Box Plot of {target_col}")
             fig_box.update_layout(template="plotly_white", height=350)
-            st.plotly_chart(fig_box, use_container_width=True)
+            st.plotly_chart(fig_box)
             skew = signals.target_stats.get("skew")
             if skew and abs(skew) > 1.5:
                 st.caption(f"ℹ️ Skew = {skew:.2f} — log transform may help.")
@@ -610,14 +610,14 @@ if regime.distribution_mode == "summary":
         summary_df = df[numeric_features].describe().T
         summary_df["skew"] = df[numeric_features].skew()
         summary_df["missing_%"] = df[numeric_features].isnull().mean() * 100
-        table(summary_df.round(3), use_container_width=True)
+        table(summary_df.round(3))
 
         # Distribution-of-distributions: skew histogram
         skews = df[numeric_features].skew().dropna()
         if len(skews) > 1:
             fig_skew = px.histogram(skews, nbins=20, title="Distribution of Feature Skewness")
             fig_skew.update_layout(template="plotly_white", height=250, xaxis_title="Skewness", yaxis_title="Count")
-            st.plotly_chart(fig_skew, use_container_width=True)
+            st.plotly_chart(fig_skew)
 else:
     # Gallery mode: paginated 3×3 grid
     filter_options = ["All Features"]
@@ -673,7 +673,7 @@ else:
                         margin=dict(l=10, r=10, t=35, b=10),
                         showlegend=False,
                     )
-                    st.plotly_chart(fig, use_container_width=True)
+                    st.plotly_chart(fig)
 
                     # Inline coaching annotation
                     if pd.api.types.is_numeric_dtype(df[feat]):
@@ -737,7 +737,7 @@ if numeric_features and regime.row_regime != "tiny":
             height=max(300, len(outlier_data) * 22 + 80),
             yaxis=dict(autorange="reversed"),
         )
-        st.plotly_chart(fig_outlier, use_container_width=True)
+        st.plotly_chart(fig_outlier)
         st.caption(f"Primary method for downstream: **{outlier_method.upper()}**. Change in sidebar settings.")
 elif not numeric_features:
     st.info("No numeric features for outlier analysis.")
@@ -759,7 +759,7 @@ if total_missing > 0:
         labels={"x": "Missing %", "y": "Column"},
     )
     fig_missing.update_layout(template="plotly_white", height=max(250, len(missing_cols) * 25 + 60))
-    st.plotly_chart(fig_missing, use_container_width=True)
+    st.plotly_chart(fig_missing)
 
     # Co-missingness pattern matrix (if meaningful)
     n_high_missing = sum(1 for v in missing_cols.values if v > 0.05)
@@ -782,7 +782,7 @@ if total_missing > 0:
                 height=max(250, len(missing_matrix.columns) * 20 + 60),
                 xaxis_title="Sample index",
             )
-            st.plotly_chart(fig_pattern, use_container_width=True)
+            st.plotly_chart(fig_pattern)
 
 
 # ============================================================================
@@ -817,7 +817,7 @@ if len(numeric_features) >= 2:
             aspect="auto",
         )
         fig_corr.update_layout(template="plotly_white", height=max(400, len(numeric_features) * 18 + 100))
-        st.plotly_chart(fig_corr, use_container_width=True)
+        st.plotly_chart(fig_corr)
 
         # List pairs above threshold (numpy-based)
         corr_vals = corr_matrix.values
@@ -917,7 +917,7 @@ if _has_target:
                         margin=dict(l=10, r=10, t=35, b=10),
                         showlegend=False,
                     )
-                    st.plotly_chart(fig, use_container_width=True)
+                    st.plotly_chart(fig)
 
 # -- Feature Explorer (interactive scatter) --------------------------------
 st.subheader("Feature Explorer")
@@ -949,7 +949,7 @@ if len(feature_cols) >= 2:
         title=f"{feat_x} vs {feat_y}",
     )
     fig_explorer.update_layout(template="plotly_white", height=450)
-    st.plotly_chart(fig_explorer, use_container_width=True)
+    st.plotly_chart(fig_explorer)
 
     # Show correlation for this pair
     if pd.api.types.is_numeric_dtype(df[feat_x]) and pd.api.types.is_numeric_dtype(df[feat_y]):
@@ -1046,7 +1046,7 @@ if regime.show_macro_shape and numeric_features:
     pca_result = compute_pca(df_numeric)
     if "error" not in pca_result:
         fig_scree = plot_scree(pca_result)
-        st.plotly_chart(fig_scree, use_container_width=True)
+        st.plotly_chart(fig_scree)
         n_90 = pca_result["n_components_90"]
         total_var = pca_result["total_variance_explained"]
         n_used = len(pca_result["feature_names"])
@@ -1079,7 +1079,7 @@ if regime.show_macro_shape and numeric_features:
 
         if selected_view == "PCA Biplot" and "error" not in pca_result:
             fig_biplot = plot_pca_biplot(pca_result, color_vals, color_label)
-            st.plotly_chart(fig_biplot, use_container_width=True)
+            st.plotly_chart(fig_biplot)
             st.caption("Arrows show feature loadings — longer arrows have more influence on this projection. "
                       "This view preserves global variance structure but hides non-linear patterns.")
 
@@ -1098,7 +1098,7 @@ if regime.show_macro_shape and numeric_features:
                 else:
                     umap_colors = None
                 fig_umap = plot_umap(umap_result, umap_colors, color_label)
-                st.plotly_chart(fig_umap, use_container_width=True)
+                st.plotly_chart(fig_umap)
                 st.caption("UMAP preserves local neighborhood structure — nearby points are genuinely similar. "
                           "Cluster sizes and inter-cluster distances are NOT meaningful.")
             else:
@@ -1111,10 +1111,10 @@ if regime.show_macro_shape and numeric_features:
                 diag_tab, barcode_tab = st.tabs(["Diagram", "Barcode"])
                 with diag_tab:
                     fig_diag = plot_persistence_diagram(tda_result)
-                    st.plotly_chart(fig_diag, use_container_width=True)
+                    st.plotly_chart(fig_diag)
                 with barcode_tab:
                     fig_barcode = plot_persistence_barcode(tda_result)
-                    st.plotly_chart(fig_barcode, use_container_width=True)
+                    st.plotly_chart(fig_barcode)
 
                 # Summary
                 for dim, info in tda_result["features_by_dim"].items():
@@ -1149,7 +1149,7 @@ if regime.show_macro_shape and numeric_features:
             if "error" not in mapper_result:
                 mapper_colors = color_vals[:len(df_numeric)] if color_vals is not None else None
                 fig_mapper = plot_mapper(mapper_result, mapper_colors, color_label)
-                st.plotly_chart(fig_mapper, use_container_width=True)
+                st.plotly_chart(fig_mapper)
                 st.caption(
                     f"Mapper approximates the data manifold as a graph ({mapper_result['n_nodes']} nodes, "
                     f"{mapper_result['n_edges']} edges). Branching reveals subpopulations; "
@@ -1349,9 +1349,9 @@ def _run_and_show(action_id: str, title: str, run_action: str, tab_key: str = ""
 
         for idx, (fig_type, fig_data) in enumerate(result.get("figures", [])):
             if fig_type == "plotly":
-                st.plotly_chart(fig_data, use_container_width=True, key=f"fig_{key_prefix}_{idx}")
+                st.plotly_chart(fig_data, key=f"fig_{key_prefix}_{idx}")
             elif fig_type == "table":
-                table(fig_data, use_container_width=True, key=f"tbl_{key_prefix}_{idx}")
+                table(fig_data, key=f"tbl_{key_prefix}_{idx}")
 
         if interp:
             st.markdown(f"**Summary:** {interp}")

--- a/pages/03_Feature_Engineering.py
+++ b/pages/03_Feature_Engineering.py
@@ -1130,7 +1130,7 @@ if new_features > 0:
                 _preview_corrs.sort(key=lambda x: x[1], reverse=True)
                 if _preview_corrs:
                     _preview_df = pd.DataFrame(_preview_corrs[:10], columns=['Feature', '|Correlation with target|'])
-                    st.dataframe(_preview_df, use_container_width=True, hide_index=True)
+                    st.dataframe(_preview_df, hide_index=True)
                     st.caption('Higher correlation suggests the feature may be predictive. Use Feature Selection (next page) for rigorous evaluation.')
                 else:
                     st.caption('Could not compute correlations for engineered features.')

--- a/pages/04_Feature_Selection.py
+++ b/pages/04_Feature_Selection.py
@@ -295,7 +295,7 @@ if results:
             ])
             # Use method name in key to avoid duplicates in loop
             safe_method = result.method.replace(" ", "_").replace("-", "_").lower()
-            table(scores_df, key=f"feature_scores_{safe_method}", use_container_width=True, hide_index=True)
+            table(scores_df, key=f"feature_scores_{safe_method}", hide_index=True)
 
             # LASSO-specific: coefficient path plot
             if result.method == "LASSO" and "path_coefs" in result.details and result.details.get("alphas"):
@@ -320,7 +320,7 @@ if results:
                         yaxis_title="Coefficient",
                         height=400,
                     )
-                    st.plotly_chart(fig, use_container_width=True)
+                    st.plotly_chart(fig)
                 except Exception as e:
                     st.caption(f"Could not render LASSO path plot: {e}")
 
@@ -342,7 +342,7 @@ if results:
                         annotation_text=f"Threshold ({stability_threshold})",
                     )
                     fig.update_layout(height=400)
-                    st.plotly_chart(fig, use_container_width=True)
+                    st.plotly_chart(fig)
                 except Exception:
                     pass
 
@@ -367,7 +367,7 @@ if results:
             matrix_data.append(row)
 
         matrix_df = pd.DataFrame(matrix_data).sort_values("Count", ascending=False)
-        table(matrix_df, key="consensus_matrix", use_container_width=True, hide_index=True)
+        table(matrix_df, key="consensus_matrix", hide_index=True)
 
         # LLM interpretation for feature selection consensus
         from utils.llm_ui import build_llm_context, render_interpretation_with_llm_button, gather_session_context

--- a/pages/06_Train_and_Compare.py
+++ b/pages/06_Train_and_Compare.py
@@ -1554,7 +1554,7 @@ if st.session_state.get('trained_models'):
                                 y_proba_pos = y_proba_local[:, 1] if y_proba_local.shape[1] == 2 else y_proba_local[:, -1]
                                 cal = calibration_classification(np.array(results["y_test"]), y_proba_pos, model_name=name.upper())
                                 fig_cal = plot_calibration_curve(cal)
-                                st.plotly_chart(fig_cal, use_container_width=True, key=f"cal_{name}")
+                                st.plotly_chart(fig_cal, key=f"cal_{name}")
                                 st.caption(f"Brier Score: {cal.brier_score:.4f} | ECE: {cal.ece:.4f} | MCE: {cal.mce:.4f}")
                         except Exception as e:
                             st.caption(f"Could not compute calibration for {name}: {e}")
@@ -1964,7 +1964,7 @@ Poor performance may be due to:
                                               title=f"ROC Curve (AUC = {roc_auc:.3f})")
                             fig_roc.add_shape(type="line", x0=0, x1=1, y0=0, y1=1, line=dict(dash="dash", color="gray"))
                             fig_roc.update_layout(template="plotly_white")
-                            st.plotly_chart(fig_roc, use_container_width=True, key=f"diag_roc_{name}")
+                            st.plotly_chart(fig_roc, key=f"diag_roc_{name}")
 
                             # Precision-Recall curve
                             prec, rec, _ = precision_recall_curve(y_true, proba_pos)
@@ -1974,7 +1974,7 @@ Poor performance may be due to:
                             baseline = np.mean(y_true == unique_classes[1]) if len(unique_classes) == 2 else 0.5
                             fig_pr.add_shape(type="line", x0=0, x1=1, y0=baseline, y1=baseline, line=dict(dash="dash", color="gray"))
                             fig_pr.update_layout(template="plotly_white")
-                            st.plotly_chart(fig_pr, use_container_width=True, key=f"diag_pr_{name}")
+                            st.plotly_chart(fig_pr, key=f"diag_pr_{name}")
 
                             # LLM interpretation for ROC + PR (combined)
                             _bg_roc = {k: v for k, v in _bg.items() if k not in ("feature_names", "sample_size", "task_type")}
@@ -1995,14 +1995,14 @@ Poor performance may be due to:
                                 fig_roc.add_trace(go.Scatter(x=fpr_i, y=tpr_i, mode='lines', name=f"Class {cls} (AUC={auc_i:.3f})"))
                             fig_roc.add_shape(type="line", x0=0, x1=1, y0=0, y1=1, line=dict(dash="dash", color="gray"))
                             fig_roc.update_layout(title="ROC Curves (One-vs-Rest)", xaxis_title="FPR", yaxis_title="TPR", template="plotly_white")
-                            st.plotly_chart(fig_roc, use_container_width=True, key=f"diag_roc_{name}")
+                            st.plotly_chart(fig_roc, key=f"diag_roc_{name}")
                     elif not model.supports_proba():
                         st.caption("This model does not support probability predictions — ROC/PR curves unavailable.")
 
                     # Confusion Matrix
                     cm = sk_confusion_matrix(results["y_test"], results["y_test_pred"])
                     fig_cm = px.imshow(cm, text_auto=True, aspect="auto", title="Confusion Matrix", labels=dict(x="Predicted", y="Actual"), color_continuous_scale="Blues")
-                    st.plotly_chart(fig_cm, use_container_width=True, key=f"diag_cm_{name}")
+                    st.plotly_chart(fig_cm, key=f"diag_cm_{name}")
                     cm_stats = analyze_confusion_matrix(results["y_test"], results["y_test_pred"])
                     nar = narrative_confusion_matrix(cm_stats, model_name=name)
                     if nar:

--- a/pages/07_Explainability.py
+++ b/pages/07_Explainability.py
@@ -641,15 +641,15 @@ if perm_data or shap_data:
                             coloraxis_showscale=False,
                             margin=dict(l=10, r=10, t=40, b=10),
                         )
-                        st.plotly_chart(fig, use_container_width=True, key=f"perm_chart_{name}")
+                        st.plotly_chart(fig, key=f"perm_chart_{name}")
 
                         with st.expander("Full rankings table"):
                             # Show appropriate columns based on whether Source was added
                             if 'Source' in importance_df.columns:
                                 table(importance_df[['Feature', 'Importance', 'Std', 'Source']], 
-                                     key=f"perm_importance_{name}", use_container_width=True, hide_index=True)
+                                     key=f"perm_importance_{name}", hide_index=True)
                             else:
-                                table(importance_df, key=f"perm_importance_{name}", use_container_width=True, hide_index=True)
+                                table(importance_df, key=f"perm_importance_{name}", hide_index=True)
 
                         from ml.plot_narrative import narrative_permutation_importance
                         nar = narrative_permutation_importance(pd_info, model_name=name)
@@ -745,16 +745,16 @@ if perm_data or shap_data:
                     fig2.update_layout(yaxis={'categoryorder': 'total ascending'}, height=350,
                                        showlegend=False, coloraxis_showscale=False,
                                        margin=dict(l=10, r=10, t=40, b=10))
-                    st.plotly_chart(fig2, use_container_width=True, key=f"shap_bar_{name}")
+                    st.plotly_chart(fig2, key=f"shap_bar_{name}")
                     
                     # Show full SHAP table with source column
                     with st.expander("Full SHAP rankings table"):
                         if 'Source' in shap_df.columns:
                             table(shap_df[['Feature', 'Mean |SHAP|', 'Source']], 
-                                 key=f"shap_importance_{name}", use_container_width=True, hide_index=True)
+                                 key=f"shap_importance_{name}", hide_index=True)
                         else:
                             table(shap_df[['Feature', 'Mean |SHAP|']], 
-                                 key=f"shap_importance_{name}", use_container_width=True, hide_index=True)
+                                 key=f"shap_importance_{name}", hide_index=True)
 
                     from ml.plot_narrative import narrative_shap
                     from utils.llm_ui import build_llm_context, render_interpretation_with_llm_button, gather_session_context
@@ -875,7 +875,7 @@ if perm_data or shap_data:
                             fig.update_layout(title=f"PDP: {fname}", xaxis_title=fname,
                                               yaxis_title="Partial Dependence",
                                               height=300, margin=dict(l=10, r=10, t=40, b=10))
-                            st.plotly_chart(fig, use_container_width=True, key=f"pdp_{name}_{fidx}")
+                            st.plotly_chart(fig, key=f"pdp_{name}_{fidx}")
                 else:
                     st.info("Partial dependence not available. Model may not support it, or permutation importance wasn't computed.")
 
@@ -914,7 +914,7 @@ if perm_data and len(perm_data) > 1:
         fig.add_trace(go.Bar(name=col, x=comp_df.index[:top_cross], y=comp_df[col][:top_cross]))
     fig.update_layout(barmode='group', title=f"Top {top_cross} Features Across Models",
                       height=400, margin=dict(l=10, r=10, t=40, b=10))
-    st.plotly_chart(fig, use_container_width=True, key="cross_model_importance")
+    st.plotly_chart(fig, key="cross_model_importance")
 
     # Consensus features
     render_guidance(
@@ -955,7 +955,7 @@ if task_final == 'regression' and len(mr) >= 2:
             pb = np.asarray(mr[mb]['y_test_pred']).ravel()
             if len(pa) == len(pb):
                 fig_ba = plot_bland_altman(pa, pb, title=f"Bland–Altman: {ma.upper()} vs {mb.upper()}", label_a=ma, label_b=mb)
-                st.plotly_chart(fig_ba, use_container_width=True, key=f"bland_altman_{ma}_{mb}")
+                st.plotly_chart(fig_ba, key=f"bland_altman_{ma}_{mb}")
                 ba_stats = analyze_bland_altman(pa, pb)
                 nar = narrative_bland_altman(ba_stats, label_a=ma, label_b=mb)
                 if nar:
@@ -1076,10 +1076,10 @@ with st.expander("Run Subgroup Analysis", expanded=False):
                         task_type=data_config.task_type or "regression",
                         n_bootstrap=200,
                     )
-                    table(sub_df[["Subgroup", "N", sub_df.columns[2], "95% CI"]], key=f"subgroup_{name}", use_container_width=True, hide_index=True)
+                    table(sub_df[["Subgroup", "N", sub_df.columns[2], "95% CI"]], key=f"subgroup_{name}", hide_index=True)
 
                     fig = plot_forest_subgroups(sub_df, metric_name=sub_df.columns[2])
-                    st.plotly_chart(fig, use_container_width=True, key=f"forest_{name}")
+                    st.plotly_chart(fig, key=f"forest_{name}")
         else:
             st.info("No suitable categorical variables found for subgroup analysis (need ≤20 unique values).")
     else:

--- a/pages/08_Sensitivity_Analysis.py
+++ b/pages/08_Sensitivity_Analysis.py
@@ -207,7 +207,7 @@ if st.button("▶️ Run Seed Sensitivity", type="primary", key="run_seed"):
 
             st.bar_chart(df_seeds.set_index("seed")[[primary_metric]])
             with st.expander("Full results table"):
-                table(df_seeds, key="seed_sensitivity", use_container_width=True)
+                table(df_seeds, key="seed_sensitivity")
 
 # Show cached results if they exist
 elif "sensitivity_seed_results" in st.session_state:
@@ -430,7 +430,7 @@ if st.button("▶️ Run Feature Dropout", type="primary", key="run_dropout"):
                 st.markdown(f"- `{row['feature']}`: removing it improved {primary_metric} by {abs(row['impact']):.4f}")
 
         with st.expander("Full dropout results"):
-            table(df_dropout[["feature", "score_without", "impact"]], key="feature_dropout", use_container_width=True)
+            table(df_dropout[["feature", "score_without", "impact"]], key="feature_dropout")
 
         # LLM interpretation for feature dropout
         from utils.llm_ui import build_llm_context, render_interpretation_with_llm_button, gather_session_context

--- a/pages/10_Report_Export.py
+++ b/pages/10_Report_Export.py
@@ -325,7 +325,7 @@ def render_export_readiness_audit(export_ctx: Dict[str, Any]) -> None:
 
     st.subheader('Export Readiness Audit')
     st.caption('This audit freezes the current session state so the export reflects what is actually available, what can be recomputed, and what is still missing.')
-    table(pd.DataFrame(rows), use_container_width=True, hide_index=True)
+    table(pd.DataFrame(rows), hide_index=True)
 
     present = sum(1 for info in export_ctx['readiness'].values() if info['status'] == 'present')
     inferred = sum(1 for info in export_ctx['readiness'].values() if info['status'] == 'inferred')
@@ -1446,7 +1446,7 @@ with st.expander("✅ TRIPOD Checklist", expanded=False):
     st.markdown(f"**{done}/{total} items addressed** (auto-completed from your workflow)")
 
     checklist_df = tracker.get_checklist_df()
-    table(checklist_df, use_container_width=True, hide_index=True)
+    table(checklist_df, hide_index=True)
 
     st.download_button(
         "📥 Download TRIPOD Checklist",
@@ -1486,7 +1486,7 @@ if st.session_state.get("table1_df") is not None:
                 
                 table1_display = pd.concat([table1_display, new_row], ignore_index=True)
         
-        table(table1_display, use_container_width=True, hide_index=True)
+        table(table1_display, hide_index=True)
         
         # Export buttons
         col_t1_exp1, col_t1_exp2 = st.columns(2)

--- a/pages/11_Theory_Reference.py
+++ b/pages/11_Theory_Reference.py
@@ -467,7 +467,7 @@ approximately symmetric, |γ₁| between 0.5 and 1 is moderately skewed, and
                 height=320, margin=dict(t=50, b=40, l=50, r=30),
                 template="plotly_white",
             )
-            st.plotly_chart(fig_skew, use_container_width=True)
+            st.plotly_chart(fig_skew)
             st.markdown(
                 "**Train your eye:** Watch two things as you slide. "
                 "First, the **gap between the red mean and green median** — in a symmetric distribution they overlap; "
@@ -601,7 +601,7 @@ distribution.
                 marker_color="rgba(22, 163, 74, 0.6)", marker_line=dict(color="rgba(22, 163, 74, 1)", width=1),
                 showlegend=False), row=1, col=2)
             fig_tf.update_layout(height=280, margin=dict(t=40, b=30, l=40, r=20), template="plotly_white")
-            st.plotly_chart(fig_tf, use_container_width=True)
+            st.plotly_chart(fig_tf)
             st.markdown(
                 "**Train your eye:** Compare the two histograms as you move λ. "
                 "At λ = 1 they're identical (no transform). As λ drops toward 0, watch the right tail in the green plot **compress** "
@@ -749,7 +749,7 @@ Dᵢ > 4/n as a more sensitive screening criterion.
                 margin=dict(t=50, b=40, l=50, r=20), template="plotly_white",
                 legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1),
             )
-            st.plotly_chart(fig_out, use_container_width=True)
+            st.plotly_chart(fig_out)
             st.markdown(
                 "**Train your eye:** The green dashed line is the fit without the outlier — it follows the data. "
                 "The red solid line includes the outlier. Move the outlier far right (high leverage) **and** far up (high residual): "
@@ -976,7 +976,7 @@ The right tool depends on *why* the extreme values exist:
             )
             fig_ct.update_xaxes(title_text="Value")
             fig_ct.update_yaxes(title_text="Count")
-            st.plotly_chart(fig_ct, use_container_width=True)
+            st.plotly_chart(fig_ct)
             st.markdown(
                 f"**What to notice:** With clipping (left), the bars at the tails don't disappear — "
                 f"their mass *piles up* at the threshold values (orange bars spike at the green lines). "
@@ -1079,7 +1079,7 @@ future data has the same collinearity structure). The problem is entirely about
                 yaxis_title="Estimated coefficient", height=340,
                 margin=dict(t=50, b=30, l=50, r=20), template="plotly_white",
             )
-            st.plotly_chart(fig_coll, use_container_width=True)
+            st.plotly_chart(fig_coll)
             st.markdown(
                 "**Train your eye:** Start at r = 0 and look at the box plots — tight, centered on the green dashed truth line. "
                 "Now slide slowly toward r = 0.9. Watch the boxes **stretch vertically** and individual dots scatter far from 2.0. "
@@ -1193,7 +1193,7 @@ to the collinear subspace.
                 margin=dict(t=50, b=30, l=50, r=30), template="plotly_white",
                 legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1),
             )
-            st.plotly_chart(fig_reg, use_container_width=True)
+            st.plotly_chart(fig_reg)
             st.markdown(
                 "**Train your eye:** Start at high correlation (r = 0.90). Ridge (purple) pulls both coefficients toward each other — "
                 "neither gets the full credit, but neither is zeroed out. LASSO (orange) makes a harsher choice: it tends to keep one and drop the other entirely. "
@@ -1361,7 +1361,7 @@ The practical implications:""")
                 yaxis_range=[0, 105], height=320,
                 margin=dict(t=50, b=40, l=60, r=20), template="plotly_white",
             )
-            st.plotly_chart(fig_curse2, use_container_width=True)
+            st.plotly_chart(fig_curse2)
             st.markdown(
                 "**Train your eye:** At p = 1 or 2, the neighborhood edge is small — you're genuinely looking at local data. "
                 "Slide p to 20: the edge length jumps above 89%, meaning your 'local' neighborhood covers almost the entire dataset along every axis. "
@@ -1443,7 +1443,7 @@ below 0.35 as requiring careful metric selection.
                 margin=dict(t=50, b=30, l=50, r=20), template="plotly_white",
                 legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1),
             )
-            st.plotly_chart(fig_imb, use_container_width=True)
+            st.plotly_chart(fig_imb)
             st.markdown(
                 "**Train your eye:** Start at 5% prevalence and compare the two bars on Accuracy — they're almost the same height. "
                 "That's the trap: a model that does *nothing* useful scores nearly as well as one that actually finds cases. "
@@ -2121,7 +2121,7 @@ steps that respects the train/test boundary.
                 yaxis_title="Accuracy (%)", yaxis_range=[0, 85], height=300,
                 margin=dict(t=50, b=30, l=50, r=20), template="plotly_white",
             )
-            st.plotly_chart(fig_leak, use_container_width=True)
+            st.plotly_chart(fig_leak)
             st.markdown(
                 "**Train your eye:** The target is pure random noise — no real signal exists. Yet the red bar (leaked selection) "
                 f"shows {leaked_acc:.0f}% accuracy, well above the 50% chance level. Why? Because feature selection on the full dataset "
@@ -2247,7 +2247,7 @@ def render_model_families():
             height=380, margin=dict(t=50, b=40, l=50, r=20), template="plotly_white",
             legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1),
         )
-        st.plotly_chart(fig_fam, use_container_width=True)
+        st.plotly_chart(fig_fam)
         st.markdown(
             "**Train your eye:** The true boundary is a gentle curve. "
             "**Linear** draws a straight line — it can't capture the curve, but it's stable and interpretable. "
@@ -2747,7 +2747,7 @@ Here 𝒩_k(**x**) is the set of *k* indices of training observations closest to
                 margin=dict(t=50, b=40, l=50, r=20), template="plotly_white",
                 legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1),
             )
-            st.plotly_chart(fig_bv, use_container_width=True)
+            st.plotly_chart(fig_bv)
             st.markdown(
                 "**Train your eye:** At k = 1, the red line jumps through every data point — it memorizes the noise (overfitting). "
                 "The train MSE is nearly zero, but the line deviates wildly from the green truth. "
@@ -3438,7 +3438,7 @@ AUPRC is the preferred metric when:
                 yaxis_title="Metric (%)", yaxis_range=[0, 110], height=300,
                 margin=dict(t=50, b=30, l=50, r=20), template="plotly_white",
             )
-            st.plotly_chart(fig_thr, use_container_width=True)
+            st.plotly_chart(fig_thr)
             st.markdown(
                 "**Train your eye:** Start at threshold = 0.50 and note the balance between precision and recall. "
                 "Now slide left toward 0.10: recall (red) climbs toward 100% because you're catching almost everyone — "
@@ -3594,7 +3594,7 @@ held-out fold for evaluation. The final metric is the average across all *k* fol
                 yaxis_title="R²", height=300,
                 margin=dict(t=50, b=30, l=50, r=20), template="plotly_white",
             )
-            st.plotly_chart(fig_cv, use_container_width=True)
+            st.plotly_chart(fig_cv)
             st.markdown(
                 "**Train your eye:** At low noise, the bars are nearly uniform — the model works consistently regardless of which fold is held out. "
                 "Now crank the noise to 4 or 5: some folds score well, others score poorly or even go negative. "
@@ -3760,7 +3760,7 @@ calibration; values above 0.05 typically warrant investigation.
                 template="plotly_white",
                 legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1),
             )
-            st.plotly_chart(fig_cal, use_container_width=True)
+            st.plotly_chart(fig_cal)
             st.markdown(
                 "**Train your eye:** The dashed diagonal is the honesty line — where every probability statement is exactly right. "
                 "At positive miscalibration, the red curve bows **below** it: the model says '80% risk' but reality is closer to 65%. "
@@ -3901,7 +3901,7 @@ Different SHAP algorithms exploit model structure for speed:
                 xaxis_title="SHAP contribution to prediction",
                 height=260, margin=dict(t=50, b=30, l=80, r=60), template="plotly_white",
             )
-            st.plotly_chart(fig_shap, use_container_width=True)
+            st.plotly_chart(fig_shap)
             st.markdown(
                 "**Train your eye:** Move the glucose slider to 180 and watch its red bar extend right — it's pushing the prediction up. "
                 "Now drop BMI to 20 and watch its bar turn blue and extend left — it's pulling the prediction down. "
@@ -4017,7 +4017,7 @@ out the opposing effects, creating a false impression of unimportance.
                 height=340, margin=dict(t=50, b=40, l=50, r=20), template="plotly_white",
                 legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1),
             )
-            st.plotly_chart(fig_pdp, use_container_width=True)
+            st.plotly_chart(fig_pdp)
             st.markdown(
                 "**Train your eye:** At high interaction strength, the red and blue ICE lines slope in **opposite directions** — "
                 "the feature matters a lot, but differently for the two groups. Now look at the thick black PDP: it's nearly flat. "
@@ -4129,7 +4129,7 @@ performance estimate is nearly meaningless.
                 xaxis_title="AUROC", xaxis_range=[0.5, 1.0],
                 height=320, margin=dict(t=50, b=40, l=140, r=20), template="plotly_white",
             )
-            st.plotly_chart(fig_sg, use_container_width=True)
+            st.plotly_chart(fig_sg)
             st.markdown(
                 "**Train your eye:** Look at the purple dashed line — that's the aggregate AUROC the paper would report. "
                 "Now look at the red dots: some subgroups fall well below that line. Increase the disparity slider and watch 'Females' and 'Site B' "
@@ -4707,7 +4707,7 @@ the mean. The app uses these thresholds:
                 yaxis_title="R²", height=300,
                 margin=dict(t=50, b=30, l=50, r=20), template="plotly_white",
             )
-            st.plotly_chart(fig_seed, use_container_width=True)
+            st.plotly_chart(fig_seed)
             st.markdown(
                 "**Train your eye:** The red bars are the best and worst seeds — they define the range of results you might have reported. "
                 "Slide the signal-to-noise ratio down: the bars spread apart, the CV% climbs, and the stability label shifts from 'Robust' toward 'Unstable.' "
@@ -4854,7 +4854,7 @@ than the other (acceleration).
                 xaxis_title="Bootstrap mean", yaxis_title="Count",
                 height=300, margin=dict(t=50, b=30, l=50, r=20), template="plotly_white",
             )
-            st.plotly_chart(fig_boot, use_container_width=True)
+            st.plotly_chart(fig_boot)
             st.markdown(
                 f"**Train your eye:** The green dotted lines mark the 95% CI: [{ci_lo:.2f}, {ci_hi:.2f}]. "
                 "Start at B = 20: the histogram is choppy and the CI boundaries jump around. "

--- a/utils/session_projects.py
+++ b/utils/session_projects.py
@@ -33,7 +33,7 @@ class SessionProjectManager:
     def create_project(self, name: str, description: str = "") -> int:
         projects = _projects()
         pid = _next_id("project")
-        now = datetime.utcnow().isoformat()
+        now = datetime.now(datetime.UTC).isoformat()
         # Deactivate others
         for p in projects.values():
             p["active"] = False
@@ -105,10 +105,10 @@ class SessionProjectManager:
             "shape_cols": shape_cols,
             "columns": columns,
             "column_types": column_types,
-            "upload_timestamp": datetime.utcnow().isoformat(),
+            "upload_timestamp": datetime.now(datetime.UTC).isoformat(),
             "is_transposed": is_transposed,
         }
-        project["updated_at"] = datetime.utcnow().isoformat()
+        project["updated_at"] = datetime.now(datetime.UTC).isoformat()
         return did
 
     def get_dataset(self, dataset_id: int) -> Optional[Dict[str, Any]]:
@@ -160,7 +160,7 @@ class SessionProjectManager:
             "result_shape_rows": result_shape[0],
             "result_shape_cols": result_shape[1],
             "result_columns": result_columns,
-            "created_at": datetime.utcnow().isoformat(),
+            "created_at": datetime.now(datetime.UTC).isoformat(),
             "is_working_table": set_as_working,
         }
         return mid

--- a/utils/table_export.py
+++ b/utils/table_export.py
@@ -6,7 +6,7 @@ import streamlit as st
 import pandas as pd
 
 
-def table(df: pd.DataFrame, use_container_width=True, hide_index=True, **kwargs):
+def table(df: pd.DataFrame, hide_index=True, **kwargs):
     """
     Render a table with downloadable export (TSV format with headers).
     

--- a/utils/theory_demos.py
+++ b/utils/theory_demos.py
@@ -55,7 +55,7 @@ def demo_skewness(page_context: str = "ref", expanded: bool = False, wrapped: bo
             height=300, margin=dict(t=50, b=40, l=50, r=30),
             template="plotly_white",
         )
-        st.plotly_chart(fig, use_container_width=True, key=f"{page_context}_skew_chart")
+        st.plotly_chart(fig, key=f"{page_context}_skew_chart")
         st.markdown(
             "**Train your eye:** Watch the **gap between mean (red) and median (green)** — "
             "as skew grows, the mean chases the tail. Linear and distance-based models are "
@@ -105,7 +105,7 @@ def demo_collinearity(page_context: str = "ref", expanded: bool = False, wrapped
             yaxis_title="Estimated coefficient", height=320,
             margin=dict(t=50, b=30, l=50, r=20), template="plotly_white",
         )
-        st.plotly_chart(fig, use_container_width=True, key=f"{page_context}_collin_chart")
+        st.plotly_chart(fig, key=f"{page_context}_collin_chart")
         st.markdown(
             "**Train your eye:** At r = 0, estimates cluster around truth. "
             "Slide to r > 0.9: they scatter wildly. The model can't tell the variables apart. "
@@ -153,7 +153,7 @@ def demo_class_imbalance(page_context: str = "ref", expanded: bool = False, wrap
             margin=dict(t=50, b=30, l=50, r=20), template="plotly_white",
             legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1),
         )
-        st.plotly_chart(fig, use_container_width=True, key=f"{page_context}_imbal_chart")
+        st.plotly_chart(fig, key=f"{page_context}_imbal_chart")
         st.markdown(
             "**Train your eye:** At low prevalence, 'always predict negative' scores near-perfect accuracy "
             "with zero recall. Slide toward 50% to see accuracy become meaningful again."
@@ -195,7 +195,7 @@ def demo_calibration(page_context: str = "ref", expanded: bool = False, wrapped:
             margin=dict(t=50, b=40, l=50, r=20), template="plotly_white",
             legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1),
         )
-        st.plotly_chart(fig, use_container_width=True, key=f"{page_context}_calib_chart")
+        st.plotly_chart(fig, key=f"{page_context}_calib_chart")
         st.markdown(
             "**Train your eye:** Below the diagonal = overconfident. Above = underconfident. "
             "Slide to 0 for perfect calibration. ECE > 0.05 warrants recalibration."
@@ -243,7 +243,7 @@ def demo_threshold(page_context: str = "ref", expanded: bool = False, wrapped: b
             yaxis_title="%", yaxis_range=[0, 110], height=280,
             margin=dict(t=50, b=30, l=50, r=20), template="plotly_white",
         )
-        st.plotly_chart(fig, use_container_width=True, key=f"{page_context}_thresh_chart")
+        st.plotly_chart(fig, key=f"{page_context}_thresh_chart")
         st.markdown(
             "**Train your eye:** Low threshold → high recall, low precision (catch everyone, many false alarms). "
             "High threshold → high precision, low recall (only flag sure cases, miss many). "
@@ -284,7 +284,7 @@ def demo_shap(page_context: str = "ref", expanded: bool = False, wrapped: bool =
             xaxis_title="SHAP contribution", height=240,
             margin=dict(t=50, b=30, l=80, r=60), template="plotly_white",
         )
-        st.plotly_chart(fig, use_container_width=True, key=f"{page_context}_shap_chart")
+        st.plotly_chart(fig, key=f"{page_context}_shap_chart")
         st.markdown(
             "**Train your eye:** Red bars push risk up; blue push it down. "
             "Contributions always sum to the gap between baseline and prediction. "
@@ -336,7 +336,7 @@ def demo_seed_sensitivity(page_context: str = "ref", expanded: bool = False, wra
             yaxis_title="R²", height=280,
             margin=dict(t=50, b=30, l=50, r=20), template="plotly_white",
         )
-        st.plotly_chart(fig, use_container_width=True, key=f"{page_context}_seed_chart")
+        st.plotly_chart(fig, key=f"{page_context}_seed_chart")
         st.markdown(
             "**Train your eye:** Red bars = best and worst seeds. If they tell different stories, "
             "report mean ± SD, not a single run."
@@ -379,7 +379,7 @@ def demo_outliers(page_context: str = "ref", expanded: bool = False, wrapped: bo
             line=dict(color="#dc2626"), name=f"With outlier (slope={c_all[0]:.2f})"))
         fig.update_layout(height=300, margin=dict(t=30, b=30, l=50, r=20), template="plotly_white",
             legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1))
-        st.plotly_chart(fig, use_container_width=True, key=f"{page_context}_outlier_chart")
+        st.plotly_chart(fig, key=f"{page_context}_outlier_chart")
         st.markdown(
             "**Train your eye:** Drag the outlier far from the cluster. The red line tilts toward it. "
             "One point can dominate a linear model's coefficients. Robust methods (Huber, RANSAC) resist this."
@@ -421,7 +421,7 @@ def demo_bias_variance(page_context: str = "ref", expanded: bool = False, wrappe
             title=f"k = {k_val} — MSE = {mse:.3f} ({label})",
             height=300, margin=dict(t=50, b=30, l=50, r=20), template="plotly_white",
             legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1))
-        st.plotly_chart(fig, use_container_width=True, key=f"{page_context}_bv_chart")
+        st.plotly_chart(fig, key=f"{page_context}_bv_chart")
         st.markdown(
             "**Train your eye:** k=1 traces every point (high variance, low bias). "
             "k=30 is nearly flat (low variance, high bias). The sweet spot minimizes total error."
@@ -456,7 +456,7 @@ def demo_bootstrap(page_context: str = "ref", expanded: bool = False, wrapped: b
             title=f"Bootstrap distribution (B={n_boot})",
             xaxis_title="Bootstrap mean", yaxis_title="Count", height=280,
             margin=dict(t=50, b=40, l=50, r=20), template="plotly_white")
-        st.plotly_chart(fig, use_container_width=True, key=f"{page_context}_boot_chart")
+        st.plotly_chart(fig, key=f"{page_context}_boot_chart")
         st.markdown(
             "**Train your eye:** More samples → smoother distribution → narrower CI. "
             "B=100 is usually enough for means; B=500+ for percentiles or complex statistics."
@@ -504,7 +504,7 @@ def demo_regularization(page_context: str = "ref", expanded: bool = False, wrapp
         fig.update_layout(barmode="group", height=280, yaxis_title="Coefficient",
             margin=dict(t=30, b=30, l=50, r=20), template="plotly_white",
             legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1))
-        st.plotly_chart(fig, use_container_width=True, key=f"{page_context}_reg_chart")
+        st.plotly_chart(fig, key=f"{page_context}_reg_chart")
         st.markdown(
             "**Train your eye:** Ridge shrinks both toward zero but keeps both. "
             "LASSO drives one to exactly zero — it selects. At high correlation, OLS estimates are unstable; regularization stabilizes them."
@@ -554,7 +554,7 @@ def demo_cross_validation(page_context: str = "ref", expanded: bool = False, wra
         fig.update_layout(
             title=f"{k}-fold CV — spread = {spread:.3f}",
             yaxis_title="R²", height=280, margin=dict(t=50, b=30, l=50, r=20), template="plotly_white")
-        st.plotly_chart(fig, use_container_width=True, key=f"{page_context}_cv_chart")
+        st.plotly_chart(fig, key=f"{page_context}_cv_chart")
         st.markdown(
             "**Train your eye:** More folds → less variation per fold but more computation. "
             "High noise → wide fold spread. Report mean ± SD, not just the mean."
@@ -590,7 +590,7 @@ def demo_transforms(page_context: str = "ref", expanded: bool = False, wrapped: 
         fig.add_trace(go.Histogram(x=raw, nbinsx=30, marker_color="rgba(220,38,38,0.6)"), row=1, col=1)
         fig.add_trace(go.Histogram(x=transformed, nbinsx=30, marker_color="rgba(22,163,74,0.6)"), row=1, col=2)
         fig.update_layout(height=260, margin=dict(t=40, b=30, l=40, r=20), template="plotly_white", showlegend=False)
-        st.plotly_chart(fig, use_container_width=True, key=f"{page_context}_transform_chart")
+        st.plotly_chart(fig, key=f"{page_context}_transform_chart")
         st.markdown(
             "**Train your eye:** λ=0 (log) aggressively compresses the right tail. "
             "λ=1 is identity (no change). Slide to find the λ that makes skewness ≈ 0."
@@ -637,7 +637,7 @@ def demo_leakage(page_context: str = "ref", expanded: bool = False, wrapped: boo
             title=f"{n_leak} leaked features — {'suspicious!' if acc_test > 90 and n_leak > 0 else 'clean' if n_leak == 0 else 'check this'}",
             yaxis_title="%", yaxis_range=[0, 110], height=260,
             margin=dict(t=50, b=30, l=50, r=20), template="plotly_white")
-        st.plotly_chart(fig, use_container_width=True, key=f"{page_context}_leak_chart")
+        st.plotly_chart(fig, key=f"{page_context}_leak_chart")
         st.markdown(
             "**Train your eye:** With 0 leaked features, accuracy is modest. Add leakage and test accuracy jumps suspiciously. "
             "R² > 0.95 on tabular data is a red flag — investigate before celebrating."
@@ -669,7 +669,7 @@ def demo_high_dimensionality(page_context: str = "ref", expanded: bool = False, 
             title=f"d={dims}: max/min distance ratio = {ratio:.1f}, mean NN dist = {mean_nn:.2f}",
             xaxis_title="Pairwise distance", yaxis_title="Count", height=260,
             margin=dict(t=50, b=40, l=50, r=20), template="plotly_white")
-        st.plotly_chart(fig, use_container_width=True, key=f"{page_context}_curse_chart")
+        st.plotly_chart(fig, key=f"{page_context}_curse_chart")
         st.markdown(
             "**Train your eye:** As dimensions grow, all distances converge — the histogram narrows. "
             "'Nearest neighbor' becomes meaningless when the nearest and farthest points are nearly equidistant."
@@ -709,7 +709,7 @@ def demo_scaling(page_context: str = "ref", expanded: bool = False, wrapped: boo
         fig.update_xaxes(title_text="Feature A (scaled)", row=1, col=2)
         fig.update_yaxes(title_text="Feature B (scaled)", row=1, col=2)
         fig.update_layout(height=280, margin=dict(t=40, b=30, l=40, r=20), template="plotly_white")
-        st.plotly_chart(fig, use_container_width=True, key=f"{page_context}_scale_chart")
+        st.plotly_chart(fig, key=f"{page_context}_scale_chart")
         st.markdown(
             f"**Train your eye:** Unscaled, Feature B dominates distance ({frac_b:.0%} of variance). "
             "After scaling, both features contribute equally. KNN, SVM, and neural nets need this; trees don't."
@@ -750,7 +750,7 @@ def demo_missing_data(page_context: str = "ref", expanded: bool = False, wrapped
             title=f"{miss_pct}% missing ({mechanism.split(' ')[0]}) — bias = {np.mean(observed) - np.mean(full):.1f}",
             margin=dict(t=50, b=30, l=50, r=20), template="plotly_white",
             legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1))
-        st.plotly_chart(fig, use_container_width=True, key=f"{page_context}_miss_chart")
+        st.plotly_chart(fig, key=f"{page_context}_miss_chart")
         st.markdown(
             "**Train your eye:** MCAR shifts the mean slightly (noise). MNAR chops the right tail — "
             "the observed mean is systematically biased downward. Median imputation amplifies this."
@@ -784,7 +784,7 @@ def demo_sample_size(page_context: str = "ref", expanded: bool = False, wrapped:
             title=f"Correlation estimates at n={n_samp} (SD={np.std(estimates):.3f})",
             yaxis_title="Estimated r", height=280, yaxis_range=[-0.3, 1.0],
             margin=dict(t=50, b=30, l=50, r=20), template="plotly_white")
-        st.plotly_chart(fig, use_container_width=True, key=f"{page_context}_sample_chart")
+        st.plotly_chart(fig, key=f"{page_context}_sample_chart")
         st.markdown(
             "**Train your eye:** At n=10, estimates scatter wildly. At n=200+, they cluster tightly around truth. "
             "Small samples can produce both inflated and deflated estimates — be cautious with effect sizes."
@@ -823,7 +823,7 @@ def demo_pdp_ice(page_context: str = "ref", expanded: bool = False, wrapped: boo
             title=f"Interaction = {interaction:.1f} — PDP {'hides the split' if interaction > 0.5 else 'is accurate'}",
             margin=dict(t=50, b=40, l=50, r=20), template="plotly_white",
             legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1))
-        st.plotly_chart(fig, use_container_width=True, key=f"{page_context}_pdp_chart")
+        st.plotly_chart(fig, key=f"{page_context}_pdp_chart")
         st.markdown(
             "**Train your eye:** The black PDP line averages over both groups. When interaction is strong, "
             "the two ICE lines diverge but the PDP splits the difference — hiding the real story. Always check ICE alongside PDP."


### PR DESCRIPTION
## Summary

Removes 71 deprecated `use_container_width=True` parameters from `st.plotly_chart()` calls (Streamlit now defaults to True) and replaces 4 `datetime.utcnow()` calls with `datetime.now(datetime.UTC)` (Python 3.12+ compatible).

## Changes

- **12 files modified**
- 71 `use_container_width=True` removed across all pages and utils
- 4 `utcnow()` → `now(datetime.UTC)` in `utils/session_projects.py`

## Testing

All 111 tests pass.

Fixes #55