### PR TITLE
refactor: unify methodology reads to InsightLedger

### DIFF
--- a/ml/publication.py
+++ b/ml/publication.py
@@ -131,24 +131,34 @@ def _describe_outlier_handling(method: str, params: Optional[Dict[str, Any]] = N
 
 def generate_methods_from_log() -> Dict[str, List[Dict[str, Any]]]:
     """Extract methodology actions grouped by step from session state log.
-    
+
+    Reads from InsightLedger first (primary), falling back to the legacy
+    methodology_log session-state list during migration.
+
     Returns:
         Dictionary mapping step name to list of log entries for that step.
     """
     try:
-        import streamlit as st
-        log = st.session_state.get('methodology_log', [])
-    except ImportError:
-        # Not in Streamlit context
-        return {}
-    
+        from utils.insight_ledger import get_ledger
+        ledger = get_ledger()
+        log = ledger.get_methodology_log()
+        if not log:
+            # Fallback to old format during migration
+            import streamlit as st
+            log = st.session_state.get('methodology_log', [])
+    except (ImportError, Exception):
+        try:
+            import streamlit as st
+            log = st.session_state.get('methodology_log', [])
+        except ImportError:
+            return {}
+
     steps = {}
     for entry in log:
         step = entry.get('step', 'Unknown')
         if step not in steps:
             steps[step] = []
         steps[step].append(entry)
-    
     return steps
 
 
@@ -329,6 +339,7 @@ def generate_methods_section(
     hyperparameter_optimization: bool = False,
     split_strategy: Optional[str] = None,
     missing_data_summary: Optional[Dict] = None,
+    ledger_narratives: Optional[Dict[str, str]] = None,
 ) -> str:
     """Generate a draft methods section for a publication.
 
@@ -1452,6 +1463,15 @@ def generate_methods_section(
                     "readers should consider the increased risk of Type I error "
                     "when interpreting individual p-values.\n\n"
                 )
+
+    if ledger_narratives:
+        sections.append('\n\n### Data Quality and Preprocessing Rationale\n')
+        sections.append(
+            'The following observations were identified during exploratory analysis '
+            'and addressed during the modeling workflow:\n'
+        )
+        for phase, narrative in ledger_narratives.items():
+            sections.append(f'**{phase}:** {narrative}\n')
 
     return "\n".join(sections)
 

--- a/pages/10_Report_Export.py
+++ b/pages/10_Report_Export.py
@@ -479,8 +479,8 @@ def _build_methods_section_for_export(
     
     # Check methodology log for hyperparameter_optimization
     hyperparameter_optimization = False
-    methodology_log = st.session_state.get('methodology_log', [])
-    for entry in methodology_log:
+    _hp_log = _report_ledger.get_methodology_log() or st.session_state.get('methodology_log', [])
+    for entry in _hp_log:
         if entry.get('step') == 'Model Training':
             details = entry.get('details', {})
             if details.get('hyperparameter_optimization'):
@@ -554,6 +554,7 @@ def _build_methods_section_for_export(
         except Exception:
             pass
 
+    _ledger_narratives = _report_ledger.to_manuscript_narrative() or None
     return generate_methods_section(
         data_config={},
         preprocessing_config=prep_config,
@@ -578,6 +579,7 @@ def _build_methods_section_for_export(
         hyperparameter_optimization=hyperparameter_optimization,
         split_strategy=split_strategy,
         missing_data_summary=missing_data_summary,
+        ledger_narratives=_ledger_narratives,
     )
 
 
@@ -1340,17 +1342,6 @@ with st.expander("📄 Auto-Generated Methods Section", expanded=False):
         )
         methods_text = _build_methods_section_for_export(manuscript_context)
 
-        # Append ledger-sourced provenance narrative
-        _ledger_narratives = _report_ledger.to_manuscript_narrative()
-        if _ledger_narratives:
-            methods_text += "\n\n### Data Quality and Preprocessing Rationale\n\n"
-            methods_text += (
-                "The following observations were identified during exploratory analysis "
-                "and addressed during the modeling workflow:\n\n"
-            )
-            for _phase, _narrative in _ledger_narratives.items():
-                methods_text += f"**{_phase}:** {_narrative}\n\n"
-
         st.session_state["methods_section"] = methods_text
         st.session_state["manuscript_export_context"] = manuscript_context
 
@@ -1618,8 +1609,8 @@ with st.expander("📝 LaTeX Manuscript Template", expanded=False):
 
         # FIX 4: Build statistical validation summary from methodology log
         stat_validation_summary = []
-        methodology_log = st.session_state.get('methodology_log', [])
-        for entry in methodology_log:
+        _sv_log = _report_ledger.get_methodology_log() or st.session_state.get('methodology_log', [])
+        for entry in _sv_log:
             if entry.get('step') == 'Statistical Validation':
                 details = entry.get('details', {})
                 action = entry.get('action', '')

--- a/tests/test_publication.py
+++ b/tests/test_publication.py
@@ -519,3 +519,57 @@ def test_generate_latex_report_fallback_methods_use_frozen_feature_names():
 
     assert 'The following 2 predictor variables were included: f1, f2.' in latex
     assert 'live1' not in latex
+
+
+def test_generate_methods_from_log_reads_from_ledger():
+    """generate_methods_from_log reads InsightLedger when it has entries."""
+    import streamlit as st
+    from ml.publication import generate_methods_from_log
+    from utils.session_state import log_methodology
+
+    saved_ledger = st.session_state.get('insight_ledger', None)
+    saved_log = st.session_state.get('methodology_log', None)
+    try:
+        # Reset both systems so the ledger is the only source
+        from utils.insight_ledger import InsightLedger
+        st.session_state['insight_ledger'] = InsightLedger()
+        st.session_state['methodology_log'] = []
+
+        log_methodology('Model Training', 'Trained Ridge', {'model': 'ridge', 'hyperparameter_optimization': True})
+
+        result = generate_methods_from_log()
+        assert 'Model Training' in result
+        entries = result['Model Training']
+        assert len(entries) >= 1
+        assert entries[0].get('step') == 'Model Training'
+    finally:
+        if saved_ledger is None:
+            st.session_state.pop('insight_ledger', None)
+        else:
+            st.session_state['insight_ledger'] = saved_ledger
+        if saved_log is None:
+            st.session_state.pop('methodology_log', None)
+        else:
+            st.session_state['methodology_log'] = saved_log
+
+
+def test_generate_methods_section_accepts_ledger_narratives():
+    """generate_methods_section integrates ledger_narratives when provided."""
+    text = generate_methods_section(
+        data_config={},
+        preprocessing_config={'numeric_scaling': 'standard'},
+        model_configs={'ridge': {}},
+        split_config={},
+        n_total=200,
+        n_train=140,
+        n_val=30,
+        n_test=30,
+        feature_names=['age', 'bmi'],
+        target_name='outcome',
+        task_type='regression',
+        metrics_used=['RMSE'],
+        ledger_narratives={'EDA': 'Skewed features were log-transformed.'},
+    )
+    assert 'Data Quality and Preprocessing Rationale' in text
+    assert 'EDA' in text
+    assert 'Skewed features were log-transformed.' in text

--- a/tests/test_unified_ledger_integration.py
+++ b/tests/test_unified_ledger_integration.py
@@ -333,6 +333,12 @@ def test_methodology_bridge(r: TestResults):
     mlog = st.session_state.get("methodology_log", [])
     r.assert_true(len(mlog) >= 4, f"methodology_log populated ({len(mlog)} entries)")
 
+    # ledger's get_methodology_log returns equivalent data
+    ledger_mlog = ledger.get_methodology_log()
+    r.assert_true(len(ledger_mlog) >= 4, f"ledger.get_methodology_log() has equivalent entries ({len(ledger_mlog)} entries)")
+    ledger_steps = {e.get("step") for e in ledger_mlog}
+    r.assert_true("Model Training" in ledger_steps, "ledger_mlog contains Model Training step")
+
 
 def test_narrative_generation(r: TestResults):
     """Test manuscript narrative and report generation."""


### PR DESCRIPTION
## Summary

Unifies the read side of the dual tracking system. All methodology reads now go through InsightLedger first, falling back to the old `methodology_log` session state for backward compatibility.

## Changes

### ml/publication.py
- `generate_methods_from_log()` reads from `InsightLedger.get_methodology_log()` first
- `generate_methods_section()` accepts `ledger_narratives` parameter to integrate provenance narrative

### pages/10_Report_Export.py
- Hyperparameter optimization check reads from ledger instead of `methodology_log`
- Statistical validation summary reads from ledger
- Ledger narratives passed into `generate_methods_section()` instead of being appended separately
- Removed the separate narrative stitching block

### Tests
- 2 new tests in test_publication.py (ledger read path + ledger_narratives parameter)
- 1 new assertion in test_unified_ledger_integration.py (ledger/methodology_log equivalence)

## Testing

113 passed, 0 failures.

## Notes

This is a **read-side migration only**. `log_methodology()` still writes to both systems. The old `methodology_log` writes can be removed in a future PR once this is proven stable.

Fixes #49