### PR TITLE
fix: wire data_config, split_config, and cv_folds to methods section

### DIFF
--- a/pages/10_Report_Export.py
+++ b/pages/10_Report_Export.py
@@ -556,10 +556,11 @@ def _build_methods_section_for_export(
 
     _ledger_narratives = _report_ledger.to_manuscript_narrative() or None
     return generate_methods_section(
-        data_config={},
+        data_config={'feature_cols': list(data_config.feature_cols) if data_config else [], 'target_col': data_config.target_col if data_config else ''},
         preprocessing_config=prep_config,
         model_configs={name: {} for name in selected_for_report},
-        split_config={},
+        split_config=split_config if split_config else {},
+        cv_folds=st.session_state.get('cv_folds', 5) if st.session_state.get('use_cv', False) else None,
         n_total=len(df),
         n_train=train_n,
         n_val=val_n,

--- a/tests/test_publication.py
+++ b/tests/test_publication.py
@@ -553,6 +553,25 @@ def test_generate_methods_from_log_reads_from_ledger():
             st.session_state['methodology_log'] = saved_log
 
 
+def test_methods_section_lists_model_names():
+    text = generate_methods_section(
+        data_config={},
+        preprocessing_config={},
+        model_configs={'ridge': {}, 'rf': {}, 'histgb_reg': {}},
+        split_config={},
+        n_total=200,
+        n_train=140,
+        n_val=30,
+        n_test=30,
+        feature_names=['feat1', 'feat2'],
+        target_name='outcome',
+        task_type='regression',
+        metrics_used=['RMSE', 'R2'],
+    )
+    assert 'RIDGE' in text or 'Ridge' in text
+    assert 'RF' in text or 'Random Forest' in text or 'rf' in text.lower()
+
+
 def test_generate_methods_section_accepts_ledger_narratives():
     """generate_methods_section integrates ledger_narratives when provided."""
     text = generate_methods_section(


### PR DESCRIPTION
## Summary

The methods section generator received empty dicts for `data_config` and `split_config`, and `cv_folds` was never passed at all. The data existed in session state — it just was not wired through.

## Changes

- `data_config={}` → passes real feature_cols and target_col
- `split_config={}` → passes real SplitConfig object
- Added `cv_folds` parameter from session state
- New test verifying model names appear in methods output

## Testing

114 passed, 0 failures.

Fixes #53