### PR TITLE
feat: complete insight lifecycle — acknowledged state, auto-gates, narrative inclusion

### DIFF
--- a/pages/05_Preprocess.py
+++ b/pages/05_Preprocess.py
@@ -1067,6 +1067,17 @@ if st.button("🔨 Build Pipelines", type="primary", key="preprocess_build_butto
         except Exception:
             pass  # Provenance recording should never break the workflow
 
+        # Auto-acknowledge unresolved EDA insights at the preprocessing gate.
+        # The user has reviewed their data, configured pipelines, and proceeded —
+        # any unresolved EDA observations are implicitly accepted.
+        try:
+            _pp_resolve_ledger.auto_acknowledge_gate(
+                gate_name="Proceeded to preprocessing",
+                source_pages=["02_EDA"],
+            )
+        except Exception:
+            pass
+
         st.success("Preprocessing pipelines built successfully. Expand each model below to view recipe and transformed data.")
         
     except Exception as e:

--- a/pages/06_Train_and_Compare.py
+++ b/pages/06_Train_and_Compare.py
@@ -1274,6 +1274,15 @@ def _train_models(models_to_train, selected_model_params, use_optimization=False
                     resolution_details=_resolve_details,
                 )
 
+        # Auto-acknowledge any remaining unresolved insights at the training gate.
+        # Training completion means the user has made all upstream decisions.
+        try:
+            _tc_ledger.auto_acknowledge_gate(
+                gate_name="Training completed",
+            )
+        except Exception:
+            pass
+
 # Class imbalance handling toggle
 if task_type_final == 'classification':
     profile = st.session_state.get('dataset_profile')

--- a/tests/test_insight_lifecycle.py
+++ b/tests/test_insight_lifecycle.py
@@ -1,0 +1,322 @@
+"""Tests for the complete insight lifecycle: created → resolved | acknowledged.
+
+Validates that:
+1. Insights can be acknowledged (reviewed and accepted without action)
+2. Auto-acknowledge gates work at workflow transitions
+3. to_manuscript_narrative() includes acknowledged insights and strengths
+4. Resolved insights are not downgraded to acknowledged
+5. The full lifecycle produces complete manuscript narratives
+"""
+
+import pytest
+from utils.insight_ledger import Insight, InsightLedger
+
+
+def _make_eda_insight(insight_id: str, finding: str, severity: str = "warning",
+                      category: str = "data_quality", model_scope=None) -> Insight:
+    """Helper to create an EDA insight."""
+    return Insight(
+        id=insight_id,
+        source_page="02_EDA",
+        category=category,
+        severity=severity,
+        finding=finding,
+        implication="Test implication",
+        recommended_action="Test action",
+        relevant_pages=["05_Preprocess"],
+        model_scope=model_scope or [],
+    )
+
+
+def _make_opportunity_insight(insight_id: str, finding: str) -> Insight:
+    """Helper to create a positive observation (opportunity) insight."""
+    return Insight(
+        id=insight_id,
+        source_page="02_EDA",
+        category="data_quality",
+        severity="info",
+        finding=finding,
+        implication="Favorable for analysis",
+        recommended_action="",
+        relevant_pages=[],
+    )
+
+
+class TestAcknowledgment:
+    """Test the acknowledge() method."""
+
+    def test_acknowledge_unresolved_insight(self):
+        ledger = InsightLedger()
+        ledger.upsert(_make_eda_insight("eda_small_sample", "Small sample size (n=200)"))
+
+        result = ledger.acknowledge("eda_small_sample", "Accepted — using regularization")
+        assert result is True
+
+        insight = ledger.get("eda_small_sample")
+        assert insight.acknowledged is True
+        assert insight.acknowledged_by == "Accepted — using regularization"
+        assert insight.acknowledged_at is not None
+        assert insight.resolved is False  # Not resolved, just acknowledged
+
+    def test_acknowledge_does_not_downgrade_resolution(self):
+        """Resolved insights should not be changed by acknowledge()."""
+        ledger = InsightLedger()
+        ledger.upsert(_make_eda_insight("eda_skew", "BMI is skewed"))
+        ledger.resolve("eda_skew", "Applied log1p", "05_Preprocess",
+                       {"action_type": "power_transform", "method": "log1p"})
+
+        # Try to acknowledge a resolved insight
+        ledger.acknowledge("eda_skew", "Should not overwrite")
+
+        insight = ledger.get("eda_skew")
+        assert insight.resolved is True
+        assert insight.acknowledged is False  # Should NOT be acknowledged
+
+    def test_acknowledge_nonexistent_returns_false(self):
+        ledger = InsightLedger()
+        result = ledger.acknowledge("nonexistent", "test")
+        assert result is False
+
+    def test_get_acknowledged_returns_only_acknowledged(self):
+        ledger = InsightLedger()
+        ledger.upsert(_make_eda_insight("eda_a", "Finding A"))
+        ledger.upsert(_make_eda_insight("eda_b", "Finding B"))
+        ledger.upsert(_make_eda_insight("eda_c", "Finding C"))
+
+        ledger.resolve("eda_a", "Fixed", "05_Preprocess")
+        ledger.acknowledge("eda_b", "Accepted")
+        # eda_c left unresolved and unacknowledged
+
+        acknowledged = ledger.get_acknowledged()
+        assert len(acknowledged) == 1
+        assert acknowledged[0].id == "eda_b"
+
+
+class TestAutoAcknowledgeGate:
+    """Test auto_acknowledge_gate() at workflow transitions."""
+
+    def test_gate_acknowledges_unresolved_eda_insights(self):
+        ledger = InsightLedger()
+        ledger.upsert(_make_eda_insight("eda_small_sample", "Small sample"))
+        ledger.upsert(_make_eda_insight("eda_leakage_col1", "Potential leakage in col1"))
+        ledger.upsert(_make_eda_insight("eda_skew", "BMI is skewed"))
+
+        # Resolve one
+        ledger.resolve("eda_skew", "Applied transform", "05_Preprocess")
+
+        # Gate: preprocessing
+        count = ledger.auto_acknowledge_gate(
+            "Proceeded to preprocessing",
+            source_pages=["02_EDA"],
+        )
+
+        assert count == 2  # small_sample and leakage (not skew — already resolved)
+
+        small = ledger.get("eda_small_sample")
+        assert small.acknowledged is True
+        assert small.acknowledged_by == "Proceeded to preprocessing"
+
+        leakage = ledger.get("eda_leakage_col1")
+        assert leakage.acknowledged is True
+
+        skew = ledger.get("eda_skew")
+        assert skew.resolved is True
+        assert skew.acknowledged is False  # Resolved, not acknowledged
+
+    def test_gate_skips_already_acknowledged(self):
+        ledger = InsightLedger()
+        ledger.upsert(_make_eda_insight("eda_a", "Finding A"))
+        ledger.acknowledge("eda_a", "Manually accepted")
+
+        count = ledger.auto_acknowledge_gate("Gate 2")
+        assert count == 0  # Already acknowledged
+
+    def test_gate_with_source_page_filter(self):
+        ledger = InsightLedger()
+        ledger.upsert(_make_eda_insight("eda_a", "EDA finding"))
+        ledger.upsert(Insight(
+            id="preprocess_issue",
+            source_page="05_Preprocess",
+            category="methodology",
+            severity="warning",
+            finding="Preprocessing issue",
+            implication="test",
+        ))
+
+        count = ledger.auto_acknowledge_gate(
+            "Proceeded to training",
+            source_pages=["02_EDA"],
+        )
+
+        assert count == 1  # Only EDA insight
+        assert ledger.get("eda_a").acknowledged is True
+        assert ledger.get("preprocess_issue").acknowledged is False
+
+    def test_gate_without_filter_acknowledges_all(self):
+        ledger = InsightLedger()
+        ledger.upsert(_make_eda_insight("eda_a", "Finding A"))
+        ledger.upsert(Insight(
+            id="other_b",
+            source_page="05_Preprocess",
+            category="methodology",
+            severity="warning",
+            finding="Other finding",
+            implication="test",
+        ))
+
+        count = ledger.auto_acknowledge_gate("Training completed")
+        assert count == 2
+
+
+class TestNarrativeWithAcknowledgments:
+    """Test that to_manuscript_narrative() includes acknowledged insights and strengths."""
+
+    def test_narrative_includes_acknowledged_limitations(self):
+        ledger = InsightLedger()
+        ledger.upsert(_make_eda_insight(
+            "eda_small_sample", "Sample size (n=200) below recommended threshold",
+            severity="warning",
+        ))
+        ledger.acknowledge("eda_small_sample", "Proceeded with regularization")
+
+        narratives = ledger.to_manuscript_narrative()
+
+        # Should appear in the EDA phase narrative
+        assert any("Sample size" in text for text in narratives.values()), \
+            f"Acknowledged limitation missing from narrative: {narratives}"
+        assert any("noted and accepted" in text for text in narratives.values()), \
+            f"Acknowledged framing missing from narrative: {narratives}"
+
+    def test_narrative_includes_strengths(self):
+        ledger = InsightLedger()
+        ledger.upsert(_make_opportunity_insight(
+            "eda_opportunity_balanced", "Balanced class distributions observed"
+        ))
+        ledger.upsert(_make_opportunity_insight(
+            "eda_opportunity_clean_data", "Minimal missing data (<1% overall)"
+        ))
+        # Auto-acknowledge at gate
+        ledger.auto_acknowledge_gate("Proceeded to preprocessing", source_pages=["02_EDA"])
+
+        narratives = ledger.to_manuscript_narrative()
+
+        assert any("favorable" in text.lower() for text in narratives.values()), \
+            f"Strengths missing from narrative: {narratives}"
+        assert any("Balanced class" in text for text in narratives.values()), \
+            f"Strength details missing: {narratives}"
+
+    def test_narrative_separates_resolved_and_acknowledged(self):
+        """Resolved and acknowledged insights should both appear but with different framing."""
+        ledger = InsightLedger()
+
+        # Resolved insight
+        ledger.upsert(_make_eda_insight("eda_skew", "BMI distribution is right-skewed"))
+        ledger.resolve("eda_skew", "Applied log1p transform", "05_Preprocess",
+                       {"action_type": "power_transform", "method": "log1p"})
+
+        # Acknowledged limitation
+        ledger.upsert(_make_eda_insight("eda_small_sample", "Small sample (n=150)"))
+        ledger.acknowledge("eda_small_sample", "Accepted with regularization")
+
+        # Strength
+        ledger.upsert(_make_opportunity_insight(
+            "eda_opportunity_strong_signal", "Strong univariate associations detected"
+        ))
+        ledger.auto_acknowledge_gate("Preprocessing", source_pages=["02_EDA"])
+
+        narratives = ledger.to_manuscript_narrative()
+        all_text = " ".join(narratives.values())
+
+        # All three types should be present
+        assert "BMI distribution" in all_text, "Resolved insight missing"
+        assert "noted and accepted" in all_text, "Acknowledged limitation missing"
+        assert "favorable" in all_text.lower(), "Strength missing"
+
+    def test_unresolved_unacknowledged_still_invisible(self):
+        """Insights that are neither resolved nor acknowledged should not appear."""
+        ledger = InsightLedger()
+        ledger.upsert(_make_eda_insight("eda_orphan", "This was never reviewed"))
+
+        narratives = ledger.to_manuscript_narrative()
+        all_text = " ".join(narratives.values()) if narratives else ""
+
+        assert "never reviewed" not in all_text
+
+
+class TestFullLifecycleIntegration:
+    """Simulate a realistic workflow and verify narrative completeness."""
+
+    def test_realistic_eda_to_training_lifecycle(self):
+        """A realistic workflow: EDA produces insights, some resolved, rest auto-acknowledged."""
+        ledger = InsightLedger()
+
+        # EDA auto-detectors produce insights
+        ledger.upsert(_make_eda_insight("eda_skew_group", "3 features exhibit right skewness",
+                                        severity="warning", model_scope=["linear", "neural"]))
+        ledger.upsert(_make_eda_insight("eda_missing_moderate", "5 features have 2-10% missing values"))
+        ledger.upsert(_make_eda_insight("eda_small_sample", "Sample size (n=180) is borderline",
+                                        severity="warning"))
+        ledger.upsert(_make_eda_insight("eda_leakage_cholesterol",
+                                        "Cholesterol shows r=0.94 with target — possible leakage"))
+        ledger.upsert(_make_opportunity_insight("eda_opportunity_balanced",
+                                                "Balanced class distributions"))
+        ledger.upsert(_make_opportunity_insight("eda_opportunity_clean_data",
+                                                "No features exceed 10% missingness"))
+
+        # Preprocess resolves some
+        ledger.resolve("eda_skew_group", "Yeo-Johnson for Ridge/MLP; raw for RF", "05_Preprocess",
+                       {"action_type": "power_transform", "per_model": {"ridge": "yeo-johnson", "rf": "none"}})
+        ledger.resolve("eda_missing_moderate", "Median imputation configured", "05_Preprocess",
+                       {"action_type": "imputation", "method": "median"})
+
+        # Preprocessing gate: auto-acknowledge remaining EDA insights
+        count = ledger.auto_acknowledge_gate("Proceeded to preprocessing", source_pages=["02_EDA"])
+        assert count == 4  # small_sample, leakage, 2 opportunities
+
+        # Training gate: should find nothing new to acknowledge (all from EDA already handled)
+        count2 = ledger.auto_acknowledge_gate("Training completed")
+        assert count2 == 0
+
+        # Check final state
+        assert ledger.get("eda_skew_group").resolved is True
+        assert ledger.get("eda_missing_moderate").resolved is True
+        assert ledger.get("eda_small_sample").acknowledged is True
+        assert ledger.get("eda_leakage_cholesterol").acknowledged is True
+        assert ledger.get("eda_opportunity_balanced").acknowledged is True
+
+        # Narrative should be comprehensive
+        narratives = ledger.to_manuscript_narrative()
+        all_text = " ".join(narratives.values())
+
+        assert "skewness" in all_text.lower() or "Yeo-Johnson" in all_text
+        assert "imput" in all_text.lower() or "median" in all_text.lower()
+        assert "noted and accepted" in all_text  # limitations
+        assert "favorable" in all_text.lower()  # strengths
+        assert "Cholesterol" in all_text or "leakage" in all_text.lower()
+
+    def test_all_resolved_no_acknowledged(self):
+        """If everything is resolved, no acknowledged section appears."""
+        ledger = InsightLedger()
+        ledger.upsert(_make_eda_insight("eda_skew", "Skewed"))
+        ledger.resolve("eda_skew", "Fixed", "05_Preprocess",
+                       {"action_type": "power_transform", "method": "log1p"})
+
+        narratives = ledger.to_manuscript_narrative()
+        all_text = " ".join(narratives.values())
+
+        assert "noted and accepted" not in all_text
+        assert "favorable" not in all_text.lower()
+
+    def test_serialization_preserves_acknowledgment(self):
+        """Acknowledged state survives to_dict → from_dict round-trip."""
+        ledger = InsightLedger()
+        ledger.upsert(_make_eda_insight("eda_a", "Finding A"))
+        ledger.acknowledge("eda_a", "Accepted")
+
+        serialized = [i.to_dict() for i in ledger.insights]
+        restored = InsightLedger.from_list(serialized)
+
+        insight = restored.get("eda_a")
+        assert insight.acknowledged is True
+        assert insight.acknowledged_by == "Accepted"
+        assert insight.acknowledged_at is not None

--- a/utils/insight_ledger.py
+++ b/utils/insight_ledger.py
@@ -495,6 +495,11 @@ class Insight:
     resolved_at: Optional[str] = None
     resolution_details: Dict[str, Any] = field(default_factory=dict)
 
+    # Acknowledgment (user reviewed and accepted without action)
+    acknowledged: bool = False
+    acknowledged_by: str = ""
+    acknowledged_at: Optional[str] = None
+
     # Timestamps
     created_at: str = field(default_factory=lambda: datetime.now().isoformat())
 
@@ -531,6 +536,9 @@ class Insight:
             "resolved_on_page": self.resolved_on_page,
             "resolved_at": self.resolved_at,
             "resolution_details": dict(self.resolution_details),
+            "acknowledged": self.acknowledged,
+            "acknowledged_by": self.acknowledged_by,
+            "acknowledged_at": self.acknowledged_at,
             "created_at": self.created_at,
             "metadata": dict(self.metadata),
         }
@@ -631,6 +639,64 @@ class InsightLedger:
             f"Check for typos in the resolution wiring."
         )
         return False
+
+    def acknowledge(
+        self,
+        insight_id: str,
+        acknowledged_by: str,
+    ) -> bool:
+        """Mark an insight as acknowledged (reviewed and accepted without action).
+
+        Acknowledged insights represent deliberate choices: the user saw the
+        observation, considered it, and proceeded without modification. This is
+        distinct from unresolved (never seen) and resolved (action taken).
+
+        Returns True if found and acknowledged.
+        """
+        for i in self._insights:
+            if i.id == insight_id:
+                if not i.resolved:  # Don't downgrade a resolution to acknowledgment
+                    i.acknowledged = True
+                    i.acknowledged_by = acknowledged_by
+                    i.acknowledged_at = datetime.now().isoformat()
+                return True
+        return False
+
+    def auto_acknowledge_gate(
+        self,
+        gate_name: str,
+        source_pages: Optional[List[str]] = None,
+    ) -> int:
+        """Auto-acknowledge unresolved insights at a workflow gate.
+
+        Called when the user proceeds past a major workflow stage (e.g.,
+        building preprocessing pipelines, starting training). Insights that
+        were created but neither resolved nor acknowledged are marked as
+        acknowledged — the user implicitly accepted them by proceeding.
+
+        Args:
+            gate_name: Human-readable gate description (e.g., "Proceeded to preprocessing")
+            source_pages: If provided, only acknowledge insights from these source pages.
+                         If None, acknowledges all unresolved insights.
+
+        Returns:
+            Number of insights acknowledged.
+        """
+        count = 0
+        for i in self._insights:
+            if i.resolved or i.acknowledged:
+                continue
+            if source_pages and i.source_page not in source_pages:
+                continue
+            i.acknowledged = True
+            i.acknowledged_by = gate_name
+            i.acknowledged_at = datetime.now().isoformat()
+            count += 1
+        return count
+
+    def get_acknowledged(self) -> List[Insight]:
+        """Return acknowledged-but-not-resolved insights."""
+        return [i for i in self._insights if i.acknowledged and not i.resolved]
 
     def remove(self, insight_id: str) -> bool:
         """Remove an insight entirely. Returns True if found."""
@@ -973,37 +1039,57 @@ class InsightLedger:
 
         Returns dict of {phase_name: narrative_text} for direct insertion
         into the LaTeX methods section.
+
+        Includes three types of insights:
+        1. Resolved: actions taken (e.g., "Skewness addressed via Yeo-Johnson transform")
+        2. Acknowledged: reviewed and accepted (e.g., "Small sample size noted; regularization applied")
+        3. Positive observations: dataset strengths (e.g., "Balanced class distributions observed")
         """
         narratives = {}
 
         seen_ids = set()  # Prevent duplicate entries across phases
         for phase_name, phase_pages in WORKFLOW_PHASES.items():
             resolved_in_phase = []
+            acknowledged_in_phase = []
+            strengths_in_phase = []
+
+            # Collect resolved insights (actions taken)
             for i in self.get_resolved():
                 if i.id in seen_ids:
                     continue
                 if not self._is_narrative_worthy(i):
-                    seen_ids.add(i.id)  # Mark as seen so it doesn't appear elsewhere
+                    seen_ids.add(i.id)
                     continue
-                # Prefer resolved_on_page (where the action happened)
                 primary_page = i.resolved_on_page or i.source_page
                 if primary_page in phase_pages:
                     resolved_in_phase.append(i)
                     seen_ids.add(i.id)
 
-            if not resolved_in_phase:
+            # Collect acknowledged insights (reviewed and accepted)
+            for i in self.get_acknowledged():
+                if i.id in seen_ids:
+                    continue
+                if i.source_page in phase_pages:
+                    # Separate strengths (opportunity/positive) from limitations
+                    if i.id.startswith("eda_opportunity_") or i.severity == "info":
+                        strengths_in_phase.append(i)
+                    else:
+                        acknowledged_in_phase.append(i)
+                    seen_ids.add(i.id)
+
+            if not resolved_in_phase and not acknowledged_in_phase and not strengths_in_phase:
                 continue
 
             sentences = []
+
+            # Render resolved insights (actions taken)
             for i in resolved_in_phase:
-                # Use structured renderer if resolution_details has action_type
                 if i.resolution_details.get("action_type"):
                     detail_prose = format_resolution_detail(
                         i.resolution_details, model_scope=i.model_scope
                     )
                     sentences.append(f"{i.finding}. {detail_prose}.")
                 else:
-                    # Legacy fallback — resolved_by + freeform details
                     detail_str = ""
                     if i.resolution_details:
                         parts = []
@@ -1026,6 +1112,37 @@ class InsightLedger:
 
                     sentences.append(
                         f"{i.finding}. {i.resolved_by}{detail_str}.{scope_str}"
+                    )
+
+            # Render acknowledged limitations
+            if acknowledged_in_phase:
+                limitations = []
+                for i in acknowledged_in_phase:
+                    if i.acknowledged_by:
+                        limitations.append(f"{i.finding} ({i.acknowledged_by})")
+                    else:
+                        limitations.append(i.finding)
+                if len(limitations) == 1:
+                    sentences.append(
+                        f"The following limitation was noted and accepted: {limitations[0]}."
+                    )
+                else:
+                    items = "; ".join(limitations)
+                    sentences.append(
+                        f"The following limitations were noted and accepted: {items}."
+                    )
+
+            # Render strengths (positive observations)
+            if strengths_in_phase:
+                strength_findings = [i.finding for i in strengths_in_phase]
+                if len(strength_findings) == 1:
+                    sentences.append(
+                        f"Dataset characteristics favorable to the analysis: {strength_findings[0]}."
+                    )
+                else:
+                    items = "; ".join(strength_findings)
+                    sentences.append(
+                        f"Dataset characteristics favorable to the analysis included: {items}."
                     )
 
             narratives[phase_name] = " ".join(sentences)


### PR DESCRIPTION
## Summary

Completes the insight lifecycle with a third resolution state: **acknowledged**. Insights can now be resolved (action taken), acknowledged (reviewed and accepted), or unresolved (not yet seen). Auto-acknowledge gates at workflow transitions ensure no insight falls through the cracks.

## Architecture

The insight lifecycle now has three terminal states:
- **Resolved**: User took action (transform, imputation, feature drop)
- **Acknowledged**: User reviewed and accepted without action (small sample, leakage investigated)
- **Unresolved**: Not yet reviewed (only state invisible to manuscript)

## Changes

### utils/insight_ledger.py
- `Insight`: Added `acknowledged`, `acknowledged_by`, `acknowledged_at` fields
- `acknowledge()`: Mark an insight as reviewed and accepted (won't downgrade a resolution)
- `auto_acknowledge_gate()`: Batch acknowledge unresolved insights at workflow transitions
- `get_acknowledged()`: Query method for acknowledged-but-not-resolved insights
- `to_manuscript_narrative()`: Now renders three categories:
  1. Resolved actions (existing behavior)
  2. Acknowledged limitations ("The following limitations were noted and accepted...")
  3. Dataset strengths ("Dataset characteristics favorable to the analysis...")

### pages/05_Preprocess.py
- Auto-acknowledge gate after pipeline build (EDA insights)

### pages/06_Train_and_Compare.py  
- Auto-acknowledge gate after training completion (all remaining insights)

## Integration with WorkflowProvenance

Complementary systems:
- WorkflowProvenance captures *what happened* (pipeline configs, per-model detail)
- InsightLedger lifecycle captures *what was considered and why* (observations, decisions, acceptances)

Together they give NarrativeEngine (#61) and TRIPOD (#57) both halves of the story.

## Testing

15 new tests. 184 total passing (166 Tier 1 + 18 Tier 2).

Fixes #56