### PR TITLE
fix: NaN guard for power transforms, LASSO alphas compat, NN sklearn MRO

### DIFF
--- a/ml/feature_selection.py
+++ b/ml/feature_selection.py
@@ -51,7 +51,10 @@ def lasso_path_selection(
         coefs = model.coef_
         optimal_alpha = model.alpha_
         # Get the path — alphas must be array-like or None
-        alphas, path_coefs, _ = lasso_path(X, y, n_alphas=n_alphas)
+        alpha_max = np.abs(X.T @ y).max() / (2.0 * X.shape[0])
+        eps = 1e-3
+        alphas_grid = np.logspace(np.log10(alpha_max), np.log10(alpha_max * eps), n_alphas)
+        alphas, path_coefs, _ = lasso_path(X, y, alphas=alphas_grid)
     else:
         coefs = model.coef_.ravel() if model.coef_.ndim > 1 else model.coef_
         optimal_alpha = 1.0 / model.C_[0] if hasattr(model, 'C_') else 0.0

--- a/ml/pipeline.py
+++ b/ml/pipeline.py
@@ -211,6 +211,8 @@ def build_preprocessing_pipeline(
             def log_transform(X):
                 return np.log1p(np.maximum(X, 0))  # log1p handles zeros
             numeric_steps.append(('log', FunctionTransformer(log_transform)))
+        if numeric_power_transform in ('yeo-johnson', 'log1p') or numeric_log_transform:
+            numeric_steps.append(('power_nan_guard', SimpleImputer(strategy='median')))
 
         # Outlier treatment
         if numeric_outlier_treatment and numeric_outlier_treatment != 'none':

--- a/models/nn_whuber.py
+++ b/models/nn_whuber.py
@@ -85,7 +85,7 @@ def weighted_huber_loss(y_pred: torch.Tensor, y_true: torch.Tensor,
     return (w * huber_loss).mean()
 
 
-class SklearnCompatibleNNRegressor(BaseEstimator, RegressorMixin):
+class SklearnCompatibleNNRegressor(RegressorMixin, BaseEstimator):
     """Sklearn-compatible wrapper for PyTorch NN model (regression)."""
     
     def __init__(self, wrapper_instance=None):
@@ -143,7 +143,7 @@ class SklearnCompatibleNNRegressor(BaseEstimator, RegressorMixin):
         return self
 
 
-class SklearnCompatibleNNClassifier(BaseEstimator, ClassifierMixin):
+class SklearnCompatibleNNClassifier(ClassifierMixin, BaseEstimator):
     """Sklearn-compatible wrapper for PyTorch NN model (classification)."""
     
     def __init__(self, wrapper_instance=None):


### PR DESCRIPTION
## Summary
- **Bug 1** (`ml/pipeline.py`): Added `SimpleImputer(strategy='median')` after power transform steps (yeo-johnson/log1p) to guard against NaN/inf values that PowerTransformer can produce on edge cases.
- **Bug 2** (`ml/feature_selection.py`): Replaced deprecated `lasso_path(n_alphas=...)` with explicit alpha grid generation using `np.logspace`, avoiding sklearn 1.7+ deprecation warning/failure.
- **Bug 3** (`models/nn_whuber.py`): Fixed MRO by swapping base class order — `RegressorMixin`/`ClassifierMixin` now precede `BaseEstimator`, required for `__sklearn_tags__` to work correctly in sklearn 1.8.

## Test plan
- [x] `pytest tests/ -x -q --ignore=tests/integration` — 192 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)