### PR TITLE
Add post-training coaching when complex models don't beat simple ones…

### DIFF
--- a/ml/model_coach.py
+++ b/ml/model_coach.py
@@ -1345,3 +1345,233 @@ def select_top_picks(profile: Any) -> Tuple[List[TopPick], List[Tuple[str, str]]
         skip_list.append(("SVM", "adds complexity without clear benefit for this data shape"))
 
     return picks, skip_list
+
+
+# ── Post-Training Diagnostics ──────────────────────────────────────────────
+
+def _model_display_name_coach(key: str) -> str:
+    """Return a human-readable model name from the coach's model info dict."""
+    info = _get_model_info()
+    return info.get(key, {}).get('name', key.upper())
+
+
+def _detect_prefer_simpler(
+    model_results: Dict[str, Dict[str, Any]],
+    task_type: str,
+    tolerance: float = 0.05,
+) -> List[Dict[str, Any]]:
+    """Detect when simple models perform within tolerance of complex ones.
+
+    Simple = interpretability 'high' (linear, GLM, Huber, etc.)
+    Complex = interpretability 'low' (boosting, neural net, etc.)
+    """
+    info = _get_model_info()
+    simple = {}  # key -> primary metric
+    complex_ = {}
+
+    for key, results in model_results.items():
+        metrics = results.get('metrics', {})
+        model_info = info.get(key, info.get(key.lower(), {}))
+        interp = model_info.get('interpretability', 'medium')
+
+        if task_type == 'regression':
+            val = metrics.get('RMSE')
+        else:
+            val = metrics.get('F1', metrics.get('Accuracy'))
+
+        if val is None:
+            continue
+        if interp == 'high':
+            simple[key] = val
+        elif interp == 'low':
+            complex_[key] = val
+
+    if not simple or not complex_:
+        return []
+
+    if task_type == 'regression':
+        best_simple_key = min(simple, key=lambda k: simple[k])
+        best_complex_key = min(complex_, key=lambda k: complex_[k])
+        best_simple_val = simple[best_simple_key]
+        best_complex_val = complex_[best_complex_key]
+        within_tolerance = best_simple_val <= best_complex_val * (1 + tolerance)
+        margin_pct = ((best_simple_val - best_complex_val) / best_complex_val * 100) if best_complex_val else 0
+        metric_name = 'RMSE'
+    else:
+        best_simple_key = max(simple, key=lambda k: simple[k])
+        best_complex_key = max(complex_, key=lambda k: complex_[k])
+        best_simple_val = simple[best_simple_key]
+        best_complex_val = complex_[best_complex_key]
+        within_tolerance = best_simple_val >= best_complex_val * (1 - tolerance)
+        margin_pct = ((best_complex_val - best_simple_val) / best_complex_val * 100) if best_complex_val else 0
+        metric_name = 'F1'
+
+    if not within_tolerance:
+        return []
+
+    simple_name = _model_display_name_coach(best_simple_key)
+    complex_name = _model_display_name_coach(best_complex_key)
+
+    return [{
+        'id': 'train_prefer_simpler',
+        'severity': 'warning',
+        'finding': (
+            f"{simple_name} performed within {abs(margin_pct):.1f}% of {complex_name} "
+            f"({metric_name} {best_simple_val:.4f} vs {best_complex_val:.4f}). "
+            "A reviewer would question why the more complex model was selected."
+        ),
+        'implication': (
+            "When models perform comparably, parsimony favors the simpler, more "
+            "interpretable model. Complex models carry higher risk of overfitting "
+            "and are harder to explain in publication."
+        ),
+        'recommended_action': (
+            f"Consider selecting {simple_name} as the primary model, or justify "
+            "the complex model's selection based on domain-specific requirements."
+        ),
+        'model_scope': [],
+        'metadata': {
+            'simple_best_model': best_simple_key,
+            'simple_best_name': simple_name,
+            'simple_best_score': float(best_simple_val),
+            'complex_best_model': best_complex_key,
+            'complex_best_name': complex_name,
+            'complex_best_score': float(best_complex_val),
+            'margin_pct': float(margin_pct),
+            'tolerance_pct': float(tolerance * 100),
+            'metric_name': metric_name,
+        },
+    }]
+
+
+def _detect_low_overall_performance(
+    model_results: Dict[str, Dict[str, Any]],
+    task_type: str,
+) -> List[Dict[str, Any]]:
+    """Detect when the best model has very low performance, suggesting feature engineering."""
+    if not model_results:
+        return []
+
+    if task_type == 'regression':
+        best_r2 = max(
+            (r.get('metrics', {}).get('R2', -1) for r in model_results.values()),
+            default=-1,
+        )
+        if best_r2 >= 0.15 or best_r2 < 0:
+            return []
+        return [{
+            'id': 'train_low_performance',
+            'severity': 'opportunity',
+            'finding': (
+                f"Best model explains only {best_r2 * 100:.1f}% of outcome variance "
+                f"(R\u00b2 = {best_r2:.3f}). This suggests the current features capture "
+                "limited predictive signal."
+            ),
+            'implication': (
+                "Low R\u00b2 may indicate that important predictors are missing, "
+                "that the relationship is non-linear and not captured by current features, "
+                "or that the outcome is inherently difficult to predict."
+            ),
+            'recommended_action': (
+                "Return to Feature Engineering to explore interaction terms, non-linear "
+                "transforms, or domain-driven composite features. Also consider whether "
+                "additional data sources are available."
+            ),
+            'model_scope': [],
+            'metadata': {'best_r2': float(best_r2)},
+        }]
+    else:
+        best_auc = max(
+            (r.get('metrics', {}).get('AUC', 0) for r in model_results.values()),
+            default=0,
+        )
+        if best_auc >= 0.60 or best_auc <= 0:
+            return []
+        return [{
+            'id': 'train_low_performance',
+            'severity': 'opportunity',
+            'finding': (
+                f"Best model achieved AUC of {best_auc:.3f}, indicating weak "
+                "discrimination between classes."
+            ),
+            'implication': (
+                "An AUC below 0.60 suggests the model barely outperforms random "
+                "guessing. The current features may not capture the decision boundary."
+            ),
+            'recommended_action': (
+                "Return to Feature Engineering to explore interaction terms, "
+                "non-linear transforms, or domain-driven composite features."
+            ),
+            'model_scope': [],
+            'metadata': {'best_auc': float(best_auc)},
+        }]
+
+
+def _detect_high_cv_variance(
+    model_results: Dict[str, Dict[str, Any]],
+    task_type: str,
+) -> List[Dict[str, Any]]:
+    """Detect when CV variance is large relative to inter-model performance gaps."""
+    cv_stds = []
+    scores = []
+    for key, results in model_results.items():
+        cv = results.get('cv_results')
+        if cv and cv.get('std') is not None:
+            cv_stds.append(cv['std'])
+        metrics = results.get('metrics', {})
+        if task_type == 'regression':
+            val = metrics.get('RMSE')
+        else:
+            val = metrics.get('F1', metrics.get('Accuracy'))
+        if val is not None:
+            scores.append(val)
+
+    if len(cv_stds) < 1 or len(scores) < 2:
+        return []
+
+    max_cv_std = max(cv_stds)
+    score_range = max(scores) - min(scores)
+
+    if score_range <= 0 or max_cv_std < score_range * 0.5:
+        return []
+
+    return [{
+        'id': 'train_cv_variance',
+        'severity': 'info',
+        'finding': (
+            f"Cross-validation variability (max std = {max_cv_std:.4f}) exceeds "
+            f"half the inter-model performance range ({score_range:.4f}). "
+            "Model ranking may not be stable."
+        ),
+        'implication': (
+            "When evaluation noise is large relative to model differences, "
+            "the apparent best model may change with different random splits. "
+            "A reviewer would question the robustness of model selection."
+        ),
+        'recommended_action': (
+            "Run Sensitivity Analysis (seed robustness) to verify that model "
+            "rankings are stable across random seeds."
+        ),
+        'model_scope': [],
+        'metadata': {
+            'max_cv_std': float(max_cv_std),
+            'score_range': float(score_range),
+        },
+    }]
+
+
+def run_post_training_diagnostics(
+    model_results: Dict[str, Dict[str, Any]],
+    task_type: str,
+    tolerance: float = 0.05,
+) -> List[Dict[str, Any]]:
+    """Run all post-training diagnostic checks and return a list of findings.
+
+    Each finding is a dict with keys: id, severity, finding, implication,
+    recommended_action, model_scope, metadata.
+    """
+    findings = []
+    findings.extend(_detect_prefer_simpler(model_results, task_type, tolerance))
+    findings.extend(_detect_low_overall_performance(model_results, task_type))
+    findings.extend(_detect_high_cv_variance(model_results, task_type))
+    return findings

--- a/ml/narrative_engine.py
+++ b/ml/narrative_engine.py
@@ -1357,6 +1357,20 @@ class NarrativeEngine:
         if len(metrics) < 2:
             return ""
 
+        # Check ledger for a prefer-simpler insight (from post-training diagnostics)
+        if self.ledger:
+            try:
+                prefer_simpler = self.ledger.get("train_prefer_simpler")
+                if prefer_simpler and not prefer_simpler.resolved:
+                    return (
+                        f"{prefer_simpler.finding} "
+                        "This pattern suggests that the available predictive signal is largely "
+                        "captured by linear effects, favoring the simpler model on grounds of "
+                        "parsimony and interpretability."
+                    )
+            except Exception:
+                pass  # Fall through to hardcoded logic
+
         simple_keys = {"ridge", "lasso", "elasticnet", "logistic", "logreg", "glm", "huber"}
         complex_keys = {
             "rf", "random_forest", "extratrees_reg", "extratrees_clf",

--- a/pages/06_Train_and_Compare.py
+++ b/pages/06_Train_and_Compare.py
@@ -1283,6 +1283,31 @@ def _train_models(models_to_train, selected_model_params, use_optimization=False
         except Exception:
             pass
 
+        # Post-training coaching: detect complexity tradeoffs and other patterns
+        try:
+            from ml.model_coach import run_post_training_diagnostics
+            from utils.insight_ledger import Insight
+            _diagnostics = run_post_training_diagnostics(
+                model_results=model_results,
+                task_type=task_type_final_local,
+            )
+            for diag in _diagnostics:
+                _tc_ledger.upsert(Insight(
+                    id=diag['id'],
+                    source_page="06_Train_and_Compare",
+                    category="model_selection",
+                    severity=diag['severity'],
+                    finding=diag['finding'],
+                    implication=diag['implication'],
+                    recommended_action=diag['recommended_action'],
+                    relevant_pages=["06_Train_and_Compare", "10_Report_Export"],
+                    tripod_keys=["model_building"],
+                    model_scope=diag.get('model_scope', []),
+                    metadata=diag.get('metadata', {}),
+                ))
+        except Exception:
+            pass  # Coaching diagnostics should never break the workflow
+
 # Class imbalance handling toggle
 if task_type_final == 'classification':
     profile = st.session_state.get('dataset_profile')
@@ -1645,7 +1670,20 @@ if st.session_state.get('trained_models'):
     # ================================================================
     st.markdown("---")
     st.markdown("### 🎯 How to Choose Your Model")
-    
+
+    # Surface prefer-simpler coaching inline if detected
+    try:
+        from utils.insight_ledger import get_ledger as _get_guidance_ledger
+        _guidance_ledger = _get_guidance_ledger()
+        _prefer_simpler = _guidance_ledger.get("train_prefer_simpler")
+        if _prefer_simpler and not _prefer_simpler.resolved:
+            st.warning(
+                f"**Simplicity Coaching:** {_prefer_simpler.finding}\n\n"
+                f"→ {_prefer_simpler.recommended_action}"
+            )
+    except Exception:
+        pass
+
     # Helper function for complexity description
     def get_model_complexity(model_name: str) -> str:
         """Return human-readable complexity description."""

--- a/tests/test_complexity_coaching.py
+++ b/tests/test_complexity_coaching.py
@@ -1,0 +1,211 @@
+"""Tests for post-training complexity coaching (issue #87).
+
+These tests verify the detection functions in ml/model_coach.py that surface
+coaching when complex models don't meaningfully beat simple ones.
+"""
+from ml.model_coach import (
+    run_post_training_diagnostics,
+    _detect_prefer_simpler,
+    _detect_low_overall_performance,
+    _detect_high_cv_variance,
+)
+
+
+# ── Prefer Simpler ──────────────────────────────────────────────────────────
+
+def test_prefer_simpler_detected_regression():
+    """Ridge within 5% of XGBoost → should trigger prefer-simpler."""
+    results = {
+        'ridge': {'metrics': {'RMSE': 0.42, 'R2': 0.55}},
+        'xgb_reg': {'metrics': {'RMSE': 0.41, 'R2': 0.57}},
+    }
+    findings = _detect_prefer_simpler(results, 'regression', tolerance=0.05)
+    assert len(findings) == 1
+    assert findings[0]['id'] == 'train_prefer_simpler'
+    assert findings[0]['severity'] == 'warning'
+    assert 'Ridge' in findings[0]['finding']
+    assert 'reviewer' in findings[0]['finding'].lower()
+    meta = findings[0]['metadata']
+    assert meta['simple_best_model'] == 'ridge'
+    assert meta['complex_best_model'] == 'xgb_reg'
+
+
+def test_prefer_simpler_not_detected_regression():
+    """Ridge much worse than XGBoost → should NOT trigger."""
+    results = {
+        'ridge': {'metrics': {'RMSE': 0.60, 'R2': 0.30}},
+        'xgb_reg': {'metrics': {'RMSE': 0.41, 'R2': 0.57}},
+    }
+    findings = _detect_prefer_simpler(results, 'regression', tolerance=0.05)
+    assert len(findings) == 0
+
+
+def test_prefer_simpler_detected_classification():
+    """Logistic within 5% of LightGBM → should trigger."""
+    results = {
+        'logreg': {'metrics': {'F1': 0.78, 'Accuracy': 0.80}},
+        'lgbm_clf': {'metrics': {'F1': 0.80, 'Accuracy': 0.82}},
+    }
+    findings = _detect_prefer_simpler(results, 'classification', tolerance=0.05)
+    assert len(findings) == 1
+    assert findings[0]['id'] == 'train_prefer_simpler'
+    assert 'Logistic' in findings[0]['finding']
+
+
+def test_prefer_simpler_not_detected_classification():
+    """Logistic much worse than LightGBM → should NOT trigger."""
+    results = {
+        'logreg': {'metrics': {'F1': 0.50, 'Accuracy': 0.55}},
+        'lgbm_clf': {'metrics': {'F1': 0.80, 'Accuracy': 0.82}},
+    }
+    findings = _detect_prefer_simpler(results, 'classification', tolerance=0.05)
+    assert len(findings) == 0
+
+
+def test_prefer_simpler_no_simple_models():
+    """Only complex models trained → no comparison possible."""
+    results = {
+        'xgb_reg': {'metrics': {'RMSE': 0.41}},
+        'nn': {'metrics': {'RMSE': 0.42}},
+    }
+    findings = _detect_prefer_simpler(results, 'regression')
+    assert len(findings) == 0
+
+
+def test_prefer_simpler_no_complex_models():
+    """Only simple models trained → no comparison possible."""
+    results = {
+        'ridge': {'metrics': {'RMSE': 0.42}},
+        'lasso': {'metrics': {'RMSE': 0.43}},
+    }
+    findings = _detect_prefer_simpler(results, 'regression')
+    assert len(findings) == 0
+
+
+# ── Low Overall Performance ─────────────────────────────────────────────────
+
+def test_low_performance_detected_regression():
+    """Best R² < 0.15 → should trigger."""
+    results = {
+        'ridge': {'metrics': {'RMSE': 0.90, 'R2': 0.10}},
+        'rf': {'metrics': {'RMSE': 0.88, 'R2': 0.12}},
+    }
+    findings = _detect_low_overall_performance(results, 'regression')
+    assert len(findings) == 1
+    assert findings[0]['id'] == 'train_low_performance'
+    assert findings[0]['severity'] == 'opportunity'
+
+
+def test_low_performance_not_detected_regression():
+    """Best R² >= 0.15 → should NOT trigger."""
+    results = {
+        'ridge': {'metrics': {'RMSE': 0.50, 'R2': 0.55}},
+    }
+    findings = _detect_low_overall_performance(results, 'regression')
+    assert len(findings) == 0
+
+
+def test_low_performance_detected_classification():
+    """Best AUC < 0.60 → should trigger."""
+    results = {
+        'logreg': {'metrics': {'AUC': 0.55, 'Accuracy': 0.60}},
+    }
+    findings = _detect_low_overall_performance(results, 'classification')
+    assert len(findings) == 1
+    assert findings[0]['id'] == 'train_low_performance'
+
+
+def test_low_performance_not_detected_classification():
+    """Best AUC >= 0.60 → should NOT trigger."""
+    results = {
+        'logreg': {'metrics': {'AUC': 0.75, 'Accuracy': 0.80}},
+    }
+    findings = _detect_low_overall_performance(results, 'classification')
+    assert len(findings) == 0
+
+
+# ── High CV Variance ────────────────────────────────────────────────────────
+
+def test_cv_variance_detected():
+    """CV std exceeds 50% of model performance range → should trigger."""
+    results = {
+        'ridge': {
+            'metrics': {'RMSE': 0.42},
+            'cv_results': {'mean': 0.43, 'std': 0.08},
+        },
+        'xgb_reg': {
+            'metrics': {'RMSE': 0.37},
+            'cv_results': {'mean': 0.38, 'std': 0.06},
+        },
+    }
+    # range = 0.42 - 0.37 = 0.05; max std = 0.08 > 0.05 * 0.5 = 0.025
+    findings = _detect_high_cv_variance(results, 'regression')
+    assert len(findings) == 1
+    assert findings[0]['id'] == 'train_cv_variance'
+    assert findings[0]['severity'] == 'info'
+
+
+def test_cv_variance_not_detected():
+    """CV std small relative to model gap → should NOT trigger."""
+    results = {
+        'ridge': {
+            'metrics': {'RMSE': 0.50},
+            'cv_results': {'mean': 0.51, 'std': 0.01},
+        },
+        'xgb_reg': {
+            'metrics': {'RMSE': 0.35},
+            'cv_results': {'mean': 0.36, 'std': 0.01},
+        },
+    }
+    # range = 0.50 - 0.35 = 0.15; max std = 0.01 < 0.15 * 0.5 = 0.075
+    findings = _detect_high_cv_variance(results, 'regression')
+    assert len(findings) == 0
+
+
+def test_cv_variance_no_cv_results():
+    """No CV results → should NOT trigger."""
+    results = {
+        'ridge': {'metrics': {'RMSE': 0.42}},
+        'xgb_reg': {'metrics': {'RMSE': 0.41}},
+    }
+    findings = _detect_high_cv_variance(results, 'regression')
+    assert len(findings) == 0
+
+
+# ── Full Diagnostic Pipeline ────────────────────────────────────────────────
+
+def test_run_post_training_diagnostics_multiple():
+    """Multiple patterns detected at once."""
+    results = {
+        'ridge': {
+            'metrics': {'RMSE': 0.92, 'R2': 0.08},
+            'cv_results': {'mean': 0.93, 'std': 0.05},
+        },
+        'xgb_reg': {
+            'metrics': {'RMSE': 0.91, 'R2': 0.09},
+            'cv_results': {'mean': 0.92, 'std': 0.04},
+        },
+    }
+    findings = run_post_training_diagnostics(results, 'regression')
+    ids = {f['id'] for f in findings}
+    # Should detect: prefer_simpler (Ridge ~= XGBoost) AND low_performance (R2 < 0.15)
+    # CV variance: range=0.01, max_std=0.05, 0.05 > 0.01*0.5=0.005 → also triggered
+    assert 'train_prefer_simpler' in ids
+    assert 'train_low_performance' in ids
+    assert 'train_cv_variance' in ids
+
+
+def test_no_triggers_when_complex_clearly_wins():
+    """Complex model clearly better, good performance, low CV noise."""
+    results = {
+        'ridge': {
+            'metrics': {'RMSE': 0.50, 'R2': 0.55},
+            'cv_results': {'mean': 0.51, 'std': 0.01},
+        },
+        'xgb_reg': {
+            'metrics': {'RMSE': 0.30, 'R2': 0.80},
+            'cv_results': {'mean': 0.31, 'std': 0.01},
+        },
+    }
+    findings = run_post_training_diagnostics(results, 'regression')
+    assert len(findings) == 0


### PR DESCRIPTION
… (#87)

Detect and surface coaching insights when:
- Simple models perform within 5% of complex ones (prefer-simpler warning)
- Best model R² < 0.15 or AUC < 0.60 (suggest feature engineering)
- CV variance exceeds half the inter-model performance range (unstable rankings)

Detection functions in ml/model_coach.py, integrated into Train & Compare page via InsightLedger, with inline coaching in Model Selection Guidance section. NarrativeEngine enhanced to read prefer-simpler insight for Discussion section.

https://claude.ai/code/session_01MWpu2DexiqWYXrdJjCrrZ2