### PR TITLE
feat: post-training coaching + stratified residuals (#87, #85)

### DIFF
--- a/ml/eval.py
+++ b/ml/eval.py
@@ -215,6 +215,86 @@ def analyze_pred_vs_actual(y_true: np.ndarray, y_pred: np.ndarray) -> Dict[str, 
     }
 
 
+def analyze_residuals_stratified(
+    y_true: np.ndarray,
+    y_pred: np.ndarray,
+    n_bins: int = 5,
+    custom_edges: Optional[List[float]] = None,
+) -> Dict[str, Any]:
+    """Residual analysis stratified by target-value range.
+
+    Returns per-bin MAE, mean bias (pred − true), RMSE, sample count,
+    and a bias_direction label ('over' / 'under' / 'balanced').
+
+    Parameters
+    ----------
+    y_true, y_pred : array-like
+        Ground-truth and predicted values.
+    n_bins : int
+        Number of equal-frequency bins (ignored when *custom_edges* given).
+    custom_edges : list of float, optional
+        Explicit bin boundaries.  Must be monotonically increasing and span
+        the target range.
+    """
+    yt = np.asarray(y_true, dtype=float).ravel()
+    yp = np.asarray(y_pred, dtype=float).ravel()
+    valid = np.isfinite(yt) & np.isfinite(yp)
+    if valid.sum() < 3:
+        return {"bins": [], "overall_bias_direction": "balanced"}
+
+    yt, yp = yt[valid], yp[valid]
+
+    if custom_edges is not None:
+        edges = np.array(sorted(custom_edges), dtype=float)
+    else:
+        percentiles = np.linspace(0, 100, n_bins + 1)
+        edges = np.percentile(yt, percentiles)
+        # deduplicate edges that collapse on repeated values
+        edges = np.unique(edges)
+
+    # ensure last edge captures max
+    edges[-1] = max(edges[-1], float(np.max(yt)) + 1e-9)
+
+    bins: List[Dict[str, Any]] = []
+    for i in range(len(edges) - 1):
+        lo, hi = edges[i], edges[i + 1]
+        mask = (yt >= lo) & (yt < hi)
+        n = int(mask.sum())
+        if n == 0:
+            bins.append({
+                "range": f"{lo:.2f}–{hi:.2f}",
+                "lo": float(lo), "hi": float(hi),
+                "n": 0, "mae": 0.0, "rmse": 0.0,
+                "mean_bias": 0.0, "bias_direction": "balanced",
+            })
+            continue
+        err = yp[mask] - yt[mask]
+        mae = float(np.mean(np.abs(err)))
+        rmse = float(np.sqrt(np.mean(err ** 2)))
+        mean_bias = float(np.mean(err))
+        if mean_bias > mae * 0.1:
+            direction = "over"
+        elif mean_bias < -mae * 0.1:
+            direction = "under"
+        else:
+            direction = "balanced"
+        bins.append({
+            "range": f"{lo:.2f}–{hi:.2f}",
+            "lo": float(lo), "hi": float(hi),
+            "n": n, "mae": mae, "rmse": rmse,
+            "mean_bias": mean_bias, "bias_direction": direction,
+        })
+
+    # overall bias direction from the worst-bias bin
+    if bins:
+        worst = max(bins, key=lambda b: abs(b["mean_bias"]))
+        overall = worst["bias_direction"]
+    else:
+        overall = "balanced"
+
+    return {"bins": bins, "overall_bias_direction": overall}
+
+
 def analyze_confusion_matrix(
     y_true: np.ndarray, y_pred: np.ndarray, labels: Optional[List[str]] = None
 ) -> Dict[str, Any]:

--- a/ml/plot_narrative.py
+++ b/ml/plot_narrative.py
@@ -61,6 +61,48 @@ def narrative_pred_vs_actual(stats: Dict[str, Any], model_name: Optional[str] = 
     return pref + " ".join(parts) if parts else ""
 
 
+def narrative_residuals_stratified(stats: Dict[str, Any], model_name: Optional[str] = None) -> str:
+    """Narrative for stratified residual analysis (scientific-inquiry tone)."""
+    bins = stats.get("bins", [])
+    if not bins:
+        return ""
+    pref = f"**{model_name or 'Model'}:** " if model_name else ""
+    parts: List[str] = []
+
+    over_bins = [b for b in bins if b["bias_direction"] == "over" and b["n"] > 0]
+    under_bins = [b for b in bins if b["bias_direction"] == "under" and b["n"] > 0]
+    worst = max(bins, key=lambda b: abs(b["mean_bias"])) if bins else None
+
+    if over_bins and under_bins:
+        parts.append(
+            "The model exhibits mixed bias across the target range — "
+            "over-predicting in some regions and under-predicting in others."
+        )
+    elif over_bins:
+        parts.append("The model tends to over-predict across the target range.")
+    elif under_bins:
+        parts.append("The model tends to under-predict across the target range.")
+    else:
+        parts.append("Predictions appear unbiased across target-value bins.")
+
+    if worst and worst["n"] > 0 and abs(worst["mean_bias"]) > 1e-6:
+        parts.append(
+            f"The largest bias occurs in the {worst['range']} range "
+            f"(mean error {worst['mean_bias']:+.4f}, n={worst['n']})."
+        )
+
+    mae_vals = [b["mae"] for b in bins if b["n"] > 0]
+    if mae_vals and max(mae_vals) > 2 * min(mae_vals):
+        best_bin = min(bins, key=lambda b: b["mae"] if b["n"] > 0 else float("inf"))
+        worst_mae = max(bins, key=lambda b: b["mae"] if b["n"] > 0 else 0)
+        parts.append(
+            f"Error varies substantially: MAE ranges from {best_bin['mae']:.4f} "
+            f"({best_bin['range']}) to {worst_mae['mae']:.4f} ({worst_mae['range']})."
+        )
+
+    return pref + " ".join(parts) if parts else ""
+
+
 def narrative_confusion_matrix(stats: Dict[str, Any], model_name: Optional[str] = None) -> str:
     """Narrative for confusion matrix."""
     if not stats:

--- a/pages/06_Train_and_Compare.py
+++ b/pages/06_Train_and_Compare.py
@@ -2005,6 +2005,80 @@ Poor performance may be due to:
                     _bg_res = {k: v for k, v in _bg.items() if k not in ("feature_names", "sample_size", "task_type")}
                     ctx = build_llm_context("residuals", stats_summary, model_name=name, model_family=_model_family, existing=nar or "", metrics=results.get("metrics"), feature_names=_feats, sample_size=_n_test, task_type=_task, **_bg_res)
                     render_interpretation_with_llm_button(ctx, key=f"llm_resid_{name}", result_session_key=f"llm_result_resid_{name}", plot_type="residuals")
+
+                    # ── Stratified residual analysis ────────────────────────
+                    st.subheader("Residuals by Target Range")
+                    from ml.eval import analyze_residuals_stratified
+                    from ml.plot_narrative import narrative_residuals_stratified
+                    import pandas as pd
+
+                    _strat_col1, _strat_col2 = st.columns([1, 3])
+                    with _strat_col1:
+                        _n_bins = st.slider(
+                            "Number of bins", min_value=3, max_value=10, value=5,
+                            key=f"strat_bins_{name}",
+                        )
+                        _custom_input = st.text_input(
+                            "Custom edges (comma-separated, optional)",
+                            key=f"strat_edges_{name}",
+                            help="e.g. 0,50,100,200 — overrides bin count",
+                        )
+                        _custom_edges = None
+                        if _custom_input.strip():
+                            try:
+                                _custom_edges = [float(x.strip()) for x in _custom_input.split(",") if x.strip()]
+                            except ValueError:
+                                st.error("Edges must be comma-separated numbers.")
+                                _custom_edges = None
+
+                    strat_stats = analyze_residuals_stratified(
+                        results["y_test"], results["y_test_pred"],
+                        n_bins=_n_bins,
+                        custom_edges=_custom_edges,
+                    )
+                    strat_bins = strat_stats.get("bins", [])
+
+                    with _strat_col2:
+                        if strat_bins:
+                            _rows = []
+                            for b in strat_bins:
+                                direction_icon = {"over": "\u2191 Over", "under": "\u2193 Under", "balanced": "\u2194 Balanced"}
+                                _rows.append({
+                                    "Range": b["range"],
+                                    "n": b["n"],
+                                    "MAE": round(b["mae"], 4),
+                                    "RMSE": round(b["rmse"], 4),
+                                    "Mean Bias": round(b["mean_bias"], 4),
+                                    "Direction": direction_icon.get(b["bias_direction"], b["bias_direction"]),
+                                })
+                            st.dataframe(pd.DataFrame(_rows), use_container_width=True, hide_index=True)
+
+                    if strat_bins:
+                        import plotly.graph_objects as go
+                        _fig_strat = go.Figure()
+                        _fig_strat.add_trace(go.Bar(
+                            x=[b["range"] for b in strat_bins],
+                            y=[b["mean_bias"] for b in strat_bins],
+                            marker_color=["#e74c3c" if b["bias_direction"] == "over"
+                                          else "#3498db" if b["bias_direction"] == "under"
+                                          else "#95a5a6" for b in strat_bins],
+                            text=[f"n={b['n']}" for b in strat_bins],
+                            textposition="outside",
+                        ))
+                        _fig_strat.update_layout(
+                            title=f"{name.upper()} — Mean Bias by Target Range",
+                            xaxis_title="Target Range",
+                            yaxis_title="Mean Bias (pred − actual)",
+                            showlegend=False,
+                            height=350,
+                        )
+                        _fig_strat.add_hline(y=0, line_dash="dash", line_color="gray")
+                        st.plotly_chart(_fig_strat, use_container_width=True, key=f"strat_bias_{name}")
+
+                        nar_strat = narrative_residuals_stratified(strat_stats, model_name=name)
+                        if nar_strat:
+                            st.markdown(f"**Summary:** {nar_strat}")
+
                 else:
                     st.subheader("Classification Performance")
                     from sklearn.metrics import confusion_matrix as sk_confusion_matrix, roc_curve, precision_recall_curve, auc

--- a/tests/test_residual_stratification.py
+++ b/tests/test_residual_stratification.py
@@ -1,0 +1,147 @@
+"""Tests for stratified residual analysis (issue #85).
+
+These tests verify analyze_residuals_stratified() in ml/eval.py
+and the narrative function in ml/plot_narrative.py.
+"""
+import numpy as np
+from ml.eval import analyze_residuals_stratified
+from ml.plot_narrative import narrative_residuals_stratified
+
+
+# ── Core analysis ──────────────────────────────────────────────────────────
+
+def test_default_quintile_bins():
+    """Default 5 bins with uniform data should produce 5 entries."""
+    np.random.seed(42)
+    y_true = np.linspace(0, 100, 100)
+    y_pred = y_true + 2  # constant over-prediction
+    result = analyze_residuals_stratified(y_true, y_pred)
+    assert len(result["bins"]) == 5
+    for b in result["bins"]:
+        assert b["n"] > 0
+        assert b["bias_direction"] == "over"
+        assert abs(b["mean_bias"] - 2.0) < 0.5
+
+
+def test_custom_edges():
+    """Custom edges override default quintile binning."""
+    y_true = np.array([10, 20, 30, 40, 50, 60, 70, 80, 90, 100], dtype=float)
+    y_pred = y_true + 1
+    result = analyze_residuals_stratified(y_true, y_pred, custom_edges=[0, 50, 100])
+    assert len(result["bins"]) == 2
+    assert result["bins"][0]["n"] + result["bins"][1]["n"] == 10
+
+
+def test_over_prediction_detected():
+    """Systematic over-prediction should be labelled 'over'."""
+    y_true = np.arange(50, dtype=float)
+    y_pred = y_true + 5
+    result = analyze_residuals_stratified(y_true, y_pred, n_bins=3)
+    for b in result["bins"]:
+        if b["n"] > 0:
+            assert b["bias_direction"] == "over"
+            assert b["mean_bias"] > 0
+
+
+def test_under_prediction_detected():
+    """Systematic under-prediction should be labelled 'under'."""
+    y_true = np.arange(50, dtype=float)
+    y_pred = y_true - 5
+    result = analyze_residuals_stratified(y_true, y_pred, n_bins=3)
+    for b in result["bins"]:
+        if b["n"] > 0:
+            assert b["bias_direction"] == "under"
+            assert b["mean_bias"] < 0
+
+
+def test_balanced_when_unbiased():
+    """Near-zero bias should be labelled 'balanced'."""
+    y_true = np.arange(100, dtype=float)
+    y_pred = y_true.copy()  # perfect predictions
+    result = analyze_residuals_stratified(y_true, y_pred, n_bins=5)
+    for b in result["bins"]:
+        if b["n"] > 0:
+            assert b["bias_direction"] == "balanced"
+            assert abs(b["mean_bias"]) < 1e-10
+
+
+def test_mae_and_rmse_correct():
+    """MAE and RMSE should be computed correctly for a simple case."""
+    y_true = np.array([10.0, 20.0, 30.0, 40.0, 50.0])
+    y_pred = np.array([12.0, 18.0, 33.0, 37.0, 55.0])
+    result = analyze_residuals_stratified(y_true, y_pred, custom_edges=[0, 25, 55])
+    bin0 = result["bins"][0]  # [0, 25): values 10, 20
+    # errors: +2, -2
+    assert abs(bin0["mae"] - 2.0) < 1e-6
+    assert abs(bin0["mean_bias"] - 0.0) < 1e-6
+    assert abs(bin0["rmse"] - 2.0) < 1e-6
+
+
+def test_too_few_samples():
+    """Fewer than 3 valid samples returns empty bins."""
+    result = analyze_residuals_stratified(np.array([1.0, 2.0]), np.array([1.0, 2.0]))
+    assert result["bins"] == []
+    assert result["overall_bias_direction"] == "balanced"
+
+
+def test_nan_handling():
+    """NaN values should be filtered out."""
+    y_true = np.array([1, 2, np.nan, 4, 5, 6, 7, 8, 9, 10], dtype=float)
+    y_pred = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, np.nan], dtype=float)
+    result = analyze_residuals_stratified(y_true, y_pred, n_bins=3)
+    total_n = sum(b["n"] for b in result["bins"])
+    assert total_n == 8  # two NaN rows removed
+
+
+def test_custom_bin_count():
+    """n_bins=3 should produce 3 bins."""
+    y_true = np.linspace(0, 100, 60)
+    y_pred = y_true + 1
+    result = analyze_residuals_stratified(y_true, y_pred, n_bins=3)
+    assert len(result["bins"]) == 3
+
+
+def test_overall_bias_direction():
+    """overall_bias_direction reflects the bin with the worst bias."""
+    y_true = np.concatenate([np.ones(20) * 10, np.ones(20) * 50])
+    y_pred = np.concatenate([np.ones(20) * 10, np.ones(20) * 60])  # over-predict high range
+    result = analyze_residuals_stratified(y_true, y_pred, n_bins=3)
+    assert result["overall_bias_direction"] == "over"
+
+
+# ── Narrative ──────────────────────────────────────────────────────────────
+
+def test_narrative_empty_stats():
+    """Empty bins produce empty narrative."""
+    assert narrative_residuals_stratified({"bins": []}) == ""
+
+
+def test_narrative_mixed_bias():
+    """Mixed bias directions should be mentioned."""
+    stats = {"bins": [
+        {"range": "0–50", "n": 10, "mae": 2.0, "rmse": 2.5, "mean_bias": 2.0, "bias_direction": "over"},
+        {"range": "50–100", "n": 10, "mae": 3.0, "rmse": 3.5, "mean_bias": -3.0, "bias_direction": "under"},
+    ]}
+    nar = narrative_residuals_stratified(stats, model_name="Ridge")
+    assert "Ridge" in nar
+    assert "mixed bias" in nar.lower() or "over-predicting" in nar.lower()
+
+
+def test_narrative_uniform_over():
+    """All over-prediction bins should produce over-prediction narrative."""
+    stats = {"bins": [
+        {"range": "0–50", "n": 10, "mae": 2.0, "rmse": 2.5, "mean_bias": 2.0, "bias_direction": "over"},
+        {"range": "50–100", "n": 10, "mae": 2.0, "rmse": 2.5, "mean_bias": 1.5, "bias_direction": "over"},
+    ]}
+    nar = narrative_residuals_stratified(stats)
+    assert "over-predict" in nar.lower()
+
+
+def test_narrative_worst_bin_mentioned():
+    """Narrative should mention the bin with the largest bias."""
+    stats = {"bins": [
+        {"range": "0–25", "n": 10, "mae": 1.0, "rmse": 1.2, "mean_bias": 0.5, "bias_direction": "over"},
+        {"range": "25–50", "n": 10, "mae": 5.0, "rmse": 6.0, "mean_bias": -5.0, "bias_direction": "under"},
+    ]}
+    nar = narrative_residuals_stratified(stats)
+    assert "25–50" in nar or "25.00–50.00" in nar


### PR DESCRIPTION
## Summary

- **Issue #87 — Simplicity coaching:** Detects when simpler models match complex ones within 5% tolerance and surfaces coaching in the Train & Compare page + NarrativeEngine discussion. Three detectors: prefer-simpler, low-overall-performance, high-CV-variance.
- **Issue #85 — Stratified residual analysis:** Breaks down residuals by target-value range (quintiles or custom edges) showing per-bin MAE, RMSE, mean bias, and over/under-prediction direction. Includes interactive table, Plotly bias bar chart, and auto-generated narrative.

## Changes

- `ml/model_coach.py` — 3 diagnostic detectors + `run_post_training_diagnostics()` wrapper
- `ml/eval.py` — `analyze_residuals_stratified()` with custom bin support
- `ml/plot_narrative.py` — `narrative_residuals_stratified()` narrative generator
- `ml/narrative_engine.py` — Ledger-aware discussion of model complexity
- `pages/06_Train_and_Compare.py` — Inline coaching UI + stratified residual section
- `tests/test_complexity_coaching.py` — 15 tests (all pass)
- `tests/test_residual_stratification.py` — 14 tests (all pass)

## Test plan

- [x] 15 complexity coaching tests pass
- [x] 14 stratified residual tests pass
- [ ] Verify coaching banner appears on Train & Compare when simple models match complex ones
- [ ] Verify stratified residual table/chart renders for regression tasks
- [ ] Confirm deployment at app.tabularml.dev after merge

https://claude.ai/code/session_01MWpu2DexiqWYXrdJjCrrZ2