### PR TITLE
feat: complexity coaching and comparative context layer (#87, #92)

### DIFF
--- a/ml/model_coach.py
+++ b/ml/model_coach.py
@@ -1726,6 +1726,79 @@ def _detect_high_cv_variance(
     }]
 
 
+def _detect_overfit(
+    model_results: Dict[str, Dict[str, Any]],
+    task_type: str,
+    gap_threshold: float = 0.10,
+) -> List[Dict[str, Any]]:
+    """Detect when train performance significantly exceeds test performance.
+
+    For regression, compares Train R² vs Test R².
+    For classification, compares Train F1 vs Test F1.
+    Flags models where the gap exceeds ``gap_threshold``.
+    """
+    info = _get_model_info()
+    findings = []
+
+    for key, results in model_results.items():
+        train_m = results.get('train_metrics', {})
+        test_m = results.get('metrics', {})
+        if not train_m:
+            continue
+
+        if task_type == 'regression':
+            train_val = train_m.get('R2')
+            test_val = test_m.get('R2')
+            metric_name = 'R²'
+        else:
+            train_val = train_m.get('F1', train_m.get('Accuracy'))
+            test_val = test_m.get('F1', test_m.get('Accuracy'))
+            metric_name = 'F1' if 'F1' in train_m else 'Accuracy'
+
+        if train_val is None or test_val is None:
+            continue
+
+        gap = train_val - test_val
+        if gap <= gap_threshold:
+            continue
+
+        display_name = _model_display_name_coach(key)
+        model_family = info.get(key, info.get(key.lower(), {}))
+        family_scope = [model_family.get('group', '').lower()] if model_family.get('group') else []
+
+        findings.append({
+            'id': f'train_overfit_{key}',
+            'severity': 'warning',
+            'finding': (
+                f"{display_name} shows signs of overfitting: train {metric_name} = "
+                f"{train_val:.3f} vs test {metric_name} = {test_val:.3f} "
+                f"(gap: {gap:.3f}). The model memorises training data patterns "
+                "that don't generalise."
+            ),
+            'implication': (
+                "Overfitting inflates apparent performance. A reviewer would note "
+                "the train/test discrepancy and question whether the model is "
+                "learning signal or noise."
+            ),
+            'recommended_action': (
+                f"Consider regularising {display_name} (increase regularisation "
+                "strength, reduce model complexity, or add dropout). Alternatively, "
+                "use a simpler model or collect more training data."
+            ),
+            'model_scope': family_scope,
+            'metadata': {
+                'model_key': key,
+                'model_name': display_name,
+                'train_score': float(train_val),
+                'test_score': float(test_val),
+                'gap': float(gap),
+                'metric_name': metric_name,
+            },
+        })
+
+    return findings
+
+
 def run_post_training_diagnostics(
     model_results: Dict[str, Dict[str, Any]],
     task_type: str,
@@ -1740,4 +1813,5 @@ def run_post_training_diagnostics(
     findings.extend(_detect_prefer_simpler(model_results, task_type, tolerance))
     findings.extend(_detect_low_overall_performance(model_results, task_type))
     findings.extend(_detect_high_cv_variance(model_results, task_type))
+    findings.extend(_detect_overfit(model_results, task_type))
     return findings

--- a/pages/06_Train_and_Compare.py
+++ b/pages/06_Train_and_Compare.py
@@ -1121,7 +1121,29 @@ def _train_models(models_to_train, selected_model_params, use_optimization=False
                 else:
                     y_test_proba = model.predict_proba(X_test_model) if model.supports_proba() else None
                     test_metrics = calculate_classification_metrics(y_test, y_test_pred, y_test_proba)
-                
+
+                # Compute train-set metrics for overfitting assessment (#92)
+                try:
+                    y_train_pred = model.predict(X_train_model)
+                    if task_type_final == 'regression' and _bt_transformer is not None:
+                        if _bt_transformer == 'log1p':
+                            y_train_pred = np.expm1(y_train_pred)
+                        else:
+                            y_train_pred = _bt_transformer.inverse_transform(
+                                y_train_pred.reshape(-1, 1)
+                            ).ravel()
+                        y_train_eval = st.session_state.get('y_train_original', y_train)
+                    else:
+                        y_train_eval = y_train
+
+                    if task_type_final == 'regression':
+                        train_metrics = calculate_regression_metrics(y_train_eval, y_train_pred)
+                    else:
+                        y_train_proba = model.predict_proba(X_train_model) if model.supports_proba() else None
+                        train_metrics = calculate_classification_metrics(y_train, y_train_pred, y_train_proba)
+                except Exception:
+                    train_metrics = {}
+
                 # Cross-validation if enabled (skip for NN - PyTorch models don't implement sklearn interface)
                 cv_results = None
                 if use_cv and model_name != 'nn':
@@ -1158,6 +1180,7 @@ def _train_models(models_to_train, selected_model_params, use_optimization=False
                 # Store results (y_test and y_test_pred are always on original scale)
                 model_results = {
                     'metrics': test_metrics,
+                    'train_metrics': train_metrics,
                     'history': results.get('history', {}),
                     'y_test_pred': y_test_pred,
                     'y_test': y_test_eval,
@@ -1458,20 +1481,93 @@ if st.session_state.get('trained_models'):
     
     # Metrics table with native copy support
     from utils.table_export import table
-    
+
     comparison_data = []
     for name, results in st.session_state.model_results.items():
         row = {'Model': name.upper()}
+        # Add train metrics columns for overfitting assessment (#92)
+        train_m = results.get('train_metrics', {})
+        if data_config.task_type == 'regression':
+            if train_m.get('R2') is not None:
+                row['Train R²'] = round(train_m['R2'], 4)
+            if train_m.get('RMSE') is not None:
+                row['Train RMSE'] = round(train_m['RMSE'], 4)
+        else:
+            if train_m.get('Accuracy') is not None:
+                row['Train Acc'] = round(train_m['Accuracy'], 4)
+            if train_m.get('F1') is not None:
+                row['Train F1'] = round(train_m['F1'], 4)
         row.update(results['metrics'])
         comparison_data.append(row)
-    
+
     comparison_df = pd.DataFrame(comparison_data)
-    
+
     if data_config.task_type == 'regression':
         comparison_df = comparison_df.sort_values('RMSE')
     else:
         comparison_df = comparison_df.sort_values('Accuracy', ascending=False)
-    
+
+    # ================================================================
+    # PERFORMANCE SPREAD SUMMARY (#92)
+    # ================================================================
+    if len(comparison_data) >= 2:
+        try:
+            from ml.model_coach import _get_model_info, _model_display_name_coach
+            _spread_info = _get_model_info()
+            if data_config.task_type == 'regression':
+                _spread_metric = 'RMSE'
+                _spread_vals = {r['Model']: r.get('RMSE') for r in comparison_data if r.get('RMSE') is not None}
+                if _spread_vals:
+                    _best_key = min(_spread_vals, key=_spread_vals.get)
+                    _worst_key = max(_spread_vals, key=_spread_vals.get)
+                    _best_val = _spread_vals[_best_key]
+                    _worst_val = _spread_vals[_worst_key]
+                    _lower_is_better = True
+            else:
+                _spread_metric = 'F1' if any(r.get('F1') is not None for r in comparison_data) else 'Accuracy'
+                _spread_vals = {r['Model']: r.get(_spread_metric) for r in comparison_data if r.get(_spread_metric) is not None}
+                if _spread_vals:
+                    _best_key = max(_spread_vals, key=_spread_vals.get)
+                    _worst_key = min(_spread_vals, key=_spread_vals.get)
+                    _best_val = _spread_vals[_best_key]
+                    _worst_val = _spread_vals[_worst_key]
+                    _lower_is_better = False
+
+            if _spread_vals and len(_spread_vals) >= 2:
+                _spread = abs(_best_val - _worst_val)
+                # Find simplest competitive model (highest interpretability within 5% of best)
+                _interp_rank = {'high': 0, 'medium': 1, 'low': 2}
+                _simplest_key = None
+                _simplest_val = None
+                for _mk, _mv in _spread_vals.items():
+                    _mk_lower = _mk.lower()
+                    _m_interp = _spread_info.get(_mk_lower, {}).get('interpretability', 'medium')
+                    if _lower_is_better:
+                        _within_tol = _mv <= _best_val * 1.05
+                    else:
+                        _within_tol = _mv >= _best_val * 0.95
+                    if _within_tol:
+                        if _simplest_key is None or _interp_rank.get(_m_interp, 1) < _interp_rank.get(
+                            _spread_info.get(_simplest_key.lower(), {}).get('interpretability', 'medium'), 1
+                        ):
+                            _simplest_key = _mk
+                            _simplest_val = _mv
+
+                # Only show spread summary; don't flag convergence if spread is large
+                _all_vals = list(_spread_vals.values())
+                _min_display = min(_all_vals)
+                _max_display = max(_all_vals)
+                _summary = (
+                    f"All {len(_spread_vals)} models achieve {_spread_metric} between "
+                    f"{_min_display:.3f} and {_max_display:.3f} (spread: {_spread:.3f}). "
+                    f"**Best:** {_best_key} ({_best_val:.3f})."
+                )
+                if _simplest_key and _simplest_key != _best_key:
+                    _summary += f" **Simplest competitive:** {_simplest_key} ({_simplest_val:.3f})."
+                st.info(_summary)
+        except Exception:
+            pass
+
     # Model metrics table with export option
     table(comparison_df, key="model_metrics")
 
@@ -1671,16 +1767,27 @@ if st.session_state.get('trained_models'):
     st.markdown("---")
     st.markdown("### 🎯 How to Choose Your Model")
 
-    # Surface prefer-simpler coaching inline if detected
+    # Surface all post-training coaching insights (#87)
     try:
         from utils.insight_ledger import get_ledger as _get_guidance_ledger
         _guidance_ledger = _get_guidance_ledger()
-        _prefer_simpler = _guidance_ledger.get("train_prefer_simpler")
-        if _prefer_simpler and not _prefer_simpler.resolved:
-            st.warning(
-                f"**Simplicity Coaching:** {_prefer_simpler.finding}\n\n"
-                f"→ {_prefer_simpler.recommended_action}"
-            )
+        _coaching_ids = ['train_prefer_simpler', 'train_low_performance', 'train_cv_variance']
+        # Also check for per-model overfit insights
+        for _mkey in st.session_state.get('model_results', {}):
+            _coaching_ids.append(f'train_overfit_{_mkey}')
+        _coaching_insights = [
+            _guidance_ledger.get(iid) for iid in _coaching_ids
+            if _guidance_ledger.get(iid) and not _guidance_ledger.get(iid).resolved
+        ]
+        if _coaching_insights:
+            st.subheader("📋 Post-Training Coaching")
+            _severity_map = {'blocker': 'error', 'warning': 'warning', 'info': 'info', 'opportunity': 'info'}
+            for _insight in _coaching_insights:
+                _st_fn = getattr(st, _severity_map.get(_insight.severity, 'info'))
+                _st_fn(
+                    f"**{_insight.finding}**\n\n"
+                    f"→ {_insight.recommended_action}"
+                )
     except Exception:
         pass
 

--- a/tests/test_comparative_context.py
+++ b/tests/test_comparative_context.py
@@ -1,0 +1,198 @@
+"""Tests for comparative context layer and overfit detection (#92, #87).
+
+Tests cover:
+- _detect_overfit() regression and classification variants
+- _detect_overfit() edge cases (no train_metrics, small gap)
+- Performance spread computation logic
+- run_post_training_diagnostics includes overfit findings
+"""
+from ml.model_coach import (
+    run_post_training_diagnostics,
+    _detect_overfit,
+    _detect_prefer_simpler,
+)
+
+
+# ── Overfit Detection ─────────────────────────────────────────────────────────
+
+def test_overfit_detected_regression():
+    """Train R² much higher than test R² → should trigger overfit warning."""
+    results = {
+        'xgb_reg': {
+            'metrics': {'RMSE': 12.0, 'R2': 0.27},
+            'train_metrics': {'RMSE': 3.0, 'R2': 0.95},
+        },
+    }
+    findings = _detect_overfit(results, 'regression', gap_threshold=0.10)
+    assert len(findings) == 1
+    assert findings[0]['id'] == 'train_overfit_xgb_reg'
+    assert findings[0]['severity'] == 'warning'
+    assert 'overfitting' in findings[0]['finding'].lower()
+    meta = findings[0]['metadata']
+    assert meta['train_score'] == 0.95
+    assert meta['test_score'] == 0.27
+    assert meta['gap'] > 0.10
+
+
+def test_overfit_not_detected_small_gap_regression():
+    """Train R² close to test R² → should NOT trigger."""
+    results = {
+        'ridge': {
+            'metrics': {'RMSE': 12.0, 'R2': 0.27},
+            'train_metrics': {'RMSE': 11.5, 'R2': 0.30},
+        },
+    }
+    findings = _detect_overfit(results, 'regression', gap_threshold=0.10)
+    assert len(findings) == 0
+
+
+def test_overfit_detected_classification():
+    """Train F1 much higher than test F1 → should trigger."""
+    results = {
+        'lgbm_clf': {
+            'metrics': {'F1': 0.60, 'Accuracy': 0.65},
+            'train_metrics': {'F1': 0.98, 'Accuracy': 0.99},
+        },
+    }
+    findings = _detect_overfit(results, 'classification', gap_threshold=0.10)
+    assert len(findings) == 1
+    assert findings[0]['id'] == 'train_overfit_lgbm_clf'
+    assert findings[0]['metadata']['gap'] > 0.10
+
+
+def test_overfit_not_detected_classification_small_gap():
+    """Train F1 close to test F1 → should NOT trigger."""
+    results = {
+        'logreg': {
+            'metrics': {'F1': 0.78, 'Accuracy': 0.80},
+            'train_metrics': {'F1': 0.82, 'Accuracy': 0.83},
+        },
+    }
+    findings = _detect_overfit(results, 'classification', gap_threshold=0.10)
+    assert len(findings) == 0
+
+
+def test_overfit_no_train_metrics():
+    """Missing train_metrics → should NOT trigger (graceful skip)."""
+    results = {
+        'ridge': {
+            'metrics': {'RMSE': 12.0, 'R2': 0.27},
+        },
+    }
+    findings = _detect_overfit(results, 'regression')
+    assert len(findings) == 0
+
+
+def test_overfit_empty_train_metrics():
+    """Empty train_metrics dict → should NOT trigger."""
+    results = {
+        'ridge': {
+            'metrics': {'RMSE': 12.0, 'R2': 0.27},
+            'train_metrics': {},
+        },
+    }
+    findings = _detect_overfit(results, 'regression')
+    assert len(findings) == 0
+
+
+def test_overfit_multiple_models():
+    """Multiple models, only one overfitting → one finding."""
+    results = {
+        'ridge': {
+            'metrics': {'RMSE': 12.0, 'R2': 0.27},
+            'train_metrics': {'RMSE': 11.5, 'R2': 0.30},
+        },
+        'xgb_reg': {
+            'metrics': {'RMSE': 12.0, 'R2': 0.27},
+            'train_metrics': {'RMSE': 2.0, 'R2': 0.97},
+        },
+    }
+    findings = _detect_overfit(results, 'regression', gap_threshold=0.10)
+    assert len(findings) == 1
+    assert findings[0]['metadata']['model_key'] == 'xgb_reg'
+
+
+def test_overfit_custom_threshold():
+    """Custom gap_threshold = 0.50 → only extreme overfitting triggers."""
+    results = {
+        'xgb_reg': {
+            'metrics': {'RMSE': 12.0, 'R2': 0.27},
+            'train_metrics': {'RMSE': 3.0, 'R2': 0.60},
+        },
+    }
+    # gap = 0.33, threshold = 0.50 → should NOT trigger
+    findings = _detect_overfit(results, 'regression', gap_threshold=0.50)
+    assert len(findings) == 0
+
+
+# ── Integration with run_post_training_diagnostics ────────────────────────────
+
+def test_diagnostics_includes_overfit():
+    """run_post_training_diagnostics should include overfit findings."""
+    results = {
+        'ridge': {
+            'metrics': {'RMSE': 12.0, 'R2': 0.27},
+            'train_metrics': {'RMSE': 11.5, 'R2': 0.30},
+        },
+        'xgb_reg': {
+            'metrics': {'RMSE': 12.0, 'R2': 0.27},
+            'train_metrics': {'RMSE': 2.0, 'R2': 0.97},
+        },
+    }
+    findings = run_post_training_diagnostics(results, 'regression')
+    overfit_findings = [f for f in findings if f['id'].startswith('train_overfit_')]
+    assert len(overfit_findings) == 1
+    assert overfit_findings[0]['metadata']['model_key'] == 'xgb_reg'
+
+
+def test_diagnostics_overfit_and_prefer_simpler_coexist():
+    """Both overfit and prefer-simpler can trigger simultaneously."""
+    results = {
+        'ridge': {
+            'metrics': {'RMSE': 0.42, 'R2': 0.55},
+            'train_metrics': {'RMSE': 0.40, 'R2': 0.58},
+        },
+        'xgb_reg': {
+            'metrics': {'RMSE': 0.41, 'R2': 0.57},
+            'train_metrics': {'RMSE': 0.10, 'R2': 0.99},
+        },
+    }
+    findings = run_post_training_diagnostics(results, 'regression', tolerance=0.05)
+    ids = [f['id'] for f in findings]
+    assert 'train_prefer_simpler' in ids
+    assert 'train_overfit_xgb_reg' in ids
+
+
+# ── Overfit finding metadata ─────────────────────────────────────────────────
+
+def test_overfit_metadata_fields():
+    """Overfit finding should have all required metadata fields."""
+    results = {
+        'histgb_reg': {
+            'metrics': {'RMSE': 10.0, 'R2': 0.30},
+            'train_metrics': {'RMSE': 2.0, 'R2': 0.95},
+        },
+    }
+    findings = _detect_overfit(results, 'regression')
+    assert len(findings) == 1
+    meta = findings[0]['metadata']
+    assert 'model_key' in meta
+    assert 'model_name' in meta
+    assert 'train_score' in meta
+    assert 'test_score' in meta
+    assert 'gap' in meta
+    assert 'metric_name' in meta
+    assert meta['metric_name'] == 'R²'
+
+
+def test_overfit_finding_has_recommended_action():
+    """Overfit finding should include actionable recommendation."""
+    results = {
+        'nn': {
+            'metrics': {'RMSE': 15.0, 'R2': 0.20},
+            'train_metrics': {'RMSE': 1.0, 'R2': 0.99},
+        },
+    }
+    findings = _detect_overfit(results, 'regression')
+    assert len(findings) == 1
+    assert 'regularis' in findings[0]['recommended_action'].lower()


### PR DESCRIPTION
Train & Compare now stores train-set metrics alongside test metrics, enabling overfitting detection and train/test gap columns in the comparison table. Performance spread summary appears above the leaderboard showing best model and simplest competitive alternative. All post-training coaching (prefer-simpler, low performance, CV variance, overfit) unified into a single coaching section. 12 new tests added.

https://claude.ai/code/session_01MWpu2DexiqWYXrdJjCrrZ2