### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: [self-hosted, clawserver]


### PR DESCRIPTION
Potential fix for [https://github.com/hedglinnolan/tabular-ml-lab/security/code-scanning/2](https://github.com/hedglinnolan/tabular-ml-lab/security/code-scanning/2)

Add an explicit `permissions` block at the workflow root in `.github/workflows/deploy.yml`, just below the trigger section and before `jobs:`.  
Best minimal fix without changing functionality is to set:

- `contents: read`

This is the least-privilege baseline for workflows that may need repository read access and avoids granting write scopes by default. No imports, methods, or dependencies are needed (YAML-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
