### PR TITLE
Fix one-click install (numba/llvmlite on Python 3.12) and delist the demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
     <strong>From raw data to a manuscript-ready starting point. No coding required.</strong>
   </p>
   <p align="center">
-    <a href="https://app.tabularml.dev">Live Demo</a> ·
     <a href="#quick-start">Quick Start</a> ·
     <a href="#features">Features</a> ·
     <a href="https://github.com/hedglinnolan/tabular-ml-lab/issues">Report Bug</a>
@@ -32,8 +31,6 @@
 An interactive research workbench for scientists who work with tabular data and need to publish papers. Upload your CSV, and the app guides you through a complete, defensible ML workflow — from exploratory analysis to a compilable LaTeX manuscript draft with auto-generated methods, results, and structured discussion.
 
 **Built for researchers, not ML engineers.** The app does the mechanical work of writing a prediction model paper. Your only edits are domain-specific context no tool can provide.
-
-> 🌐 **Try it now:** [app.tabularml.dev](https://app.tabularml.dev) (Note: I am actively developing a new branch and I use this demo website to test out new features. Functionality may break once in a while.)
 
 ## ⬇️ Download the App (no coding, no terminal)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,13 @@ statsmodels>=0.14.0
 matplotlib>=3.7.0
 plotly>=5.14.0
 shap>=0.42.0
+# shap pulls in numba/llvmlite transitively. numpy has no upper bound here, so
+# the resolver takes its newest release — which excludes every modern numba
+# (they cap numpy tightly) and backtracks to numba 0.53 / llvmlite 0.36, a 2021
+# build with no Python 3.12 wheel that then fails to compile on install. Floor
+# both to modern releases that ship 3.12/3.13 wheels; uv caps numpy to match.
+numba>=0.60
+llvmlite>=0.43
 kaleido>=0.2.1
 optuna>=3.0.0
 openpyxl>=3.1.0


### PR DESCRIPTION
Two small post-merge fixes ahead of the demo.

## Install fix — the one-click download was failing (`46e9fd7`)
On a real Windows machine the download aborted with:

> `Failed to build llvmlite==0.36.0 … Cannot install on Python version 3.12.13; only versions >=3.6,<3.10 are supported.`

**Root cause:** `requirements.txt` left `numpy` unbounded, so the resolver took its newest release. Every modern `numba` pins numpy tightly and was excluded, so uv backtracked `numba` to 0.53.1 / `llvmlite` 0.36.0 — a 2021 build whose loose metadata "fit" the too-new numpy but which ships wheels only for Python <3.10. On 3.12 it tried to compile from source and hit the version guard.

**Fix:** floor `numba>=0.60` and `llvmlite>=0.43` (both ship `cp312`/`cp313` wheels for Windows, macOS, and Linux). uv now selects numba 0.66 / llvmlite 0.48 and caps numpy to 2.4.6 to match — `shap` stays at 0.52.0, no feature loss.

**Verified:** resolves cleanly on Python 3.12 and 3.13; the formerly-failing packages install from binary wheels with `--no-build`; Windows `cp312-win_amd64` and macOS `cp312` wheels confirmed present on PyPI. The launcher's `.venv` stamp hashes `requirements.txt`, so returning users get a one-time automatic rebuild onto the fixed pins.

## Delist the demo link (`d676cf9`)
The public demo site (`app.tabularml.dev`) is temporarily offline, so removed the "Live Demo" header link and the "Try it now" callout from the README. The one-click download and local quick-start paths are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Y6pZssF946f2jqcuoYKkz

---
_Generated by [Claude Code](https://claude.ai/code/session_016Y6pZssF946f2jqcuoYKkz)_