### PR TITLE
Fix launcher: open the browser tab on first run without hanging

### DIFF
--- a/launcher/posix_launch.sh
+++ b/launcher/posix_launch.sh
@@ -128,9 +128,22 @@ if [[ "$FROM_APP" == "--from-app" ]]; then
     notify_mac "Starting Tabular ML Lab — your browser will open shortly."
 else
     say "Starting Tabular ML Lab — your browser will open automatically."
+    note "If it doesn't open, go to http://localhost:8501 in your browser."
     note "Keep this window open while you work; closing it quits the app."
 fi
 
+# On first run a non-headless Streamlit prompts for an email on stdin and
+# blocks until you answer — which would hang this launcher. Pre-seed the empty
+# credential it would otherwise write, so the prompt never appears.
+if [[ ! -f "$HOME/.streamlit/credentials.toml" ]]; then
+    mkdir -p "$HOME/.streamlit"
+    printf '[general]\nemail = ""\n' > "$HOME/.streamlit/credentials.toml"
+fi
+
 cd "$ROOT"
+# --server.headless false overrides headless=true in .streamlit/config.toml
+# (that default suits server/Docker deploys); on a desktop we want Streamlit
+# to open the browser tab itself. CLI flags win over the config file.
 exec "$VENV/bin/python" -m streamlit run "$ROOT/app.py" \
+    --server.headless false \
     --browser.gatherUsageStats false

--- a/launcher/windows_setup.ps1
+++ b/launcher/windows_setup.ps1
@@ -78,9 +78,22 @@ try {
 
     # -- 4. Launch --------------------------------------------------------
     Say "Starting Tabular ML Lab - your browser will open automatically."
+    Note "If it doesn't open, go to http://localhost:8501 in your browser."
     Note "Keep this window open while you work; closing it quits the app."
+    # On first run a non-headless Streamlit prompts for an email on stdin and
+    # blocks until you answer - which would hang this launcher. Pre-seed the
+    # empty credential it would otherwise write, so the prompt never appears.
+    $CredDir = Join-Path $env:USERPROFILE ".streamlit"
+    $CredFile = Join-Path $CredDir "credentials.toml"
+    if (-not (Test-Path $CredFile)) {
+        New-Item -ItemType Directory -Force -Path $CredDir | Out-Null
+        Set-Content -Path $CredFile -Value "[general]`r`nemail = `"`""
+    }
     Set-Location $Root
-    & $Py -m streamlit run (Join-Path $Root "app.py") --browser.gatherUsageStats false
+    # --server.headless false overrides headless=true in .streamlit/config.toml
+    # (that default suits server/Docker deploys); on a desktop we want Streamlit
+    # to open the browser tab itself. CLI flags win over the config file.
+    & $Py -m streamlit run (Join-Path $Root "app.py") --server.headless false --browser.gatherUsageStats false
     exit $LASTEXITCODE
 }
 catch {


### PR DESCRIPTION
The one-click launcher told users "your browser will open automatically," but no tab appeared. Two coupled causes:

1. **`.streamlit/config.toml` sets `headless = true`** — the right default for server/Docker deploys, but it suppresses Streamlit's browser auto-open. So on a desktop the app started fine at `localhost:8501` and just never opened a tab.
2. Overriding with `--server.headless false` restores auto-open, **but on a first-ever run a non-headless Streamlit prompts for an email on stdin and blocks** — which would hang the launcher instead.

**Fix (both launchers):** pre-seed `~/.streamlit/credentials.toml` with an empty email (exactly what Streamlit writes when you press Enter at that prompt) so it never appears, then pass `--server.headless false` so Streamlit opens the tab itself. Also print `http://localhost:8501` as a visible fallback in case auto-open is blocked by the OS.

The committed `headless = true` default is left untouched, so server/Docker deployments are unaffected — only the desktop launchers override it.

**Verified:** in an isolated `HOME` with the pre-seeded credential, `--server.headless false` starts in ~3 s, shows no email prompt, and serves HTTP 200; `tests/test_distribution.py` green.

Note for users: the app is a local web server you view in a browser tab — you never need to close or reopen your browser, and nothing is hosted online in this mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Y6pZssF946f2jqcuoYKkz

---
_Generated by [Claude Code](https://claude.ai/code/session_016Y6pZssF946f2jqcuoYKkz)_