### PR TITLE
Fix feature-engineering state drift; lock Test% under the lockbox; strategy-aware CV

### DIFF
--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -323,3 +323,58 @@ Distilled from this review's confirmed defects; each rule traces to a real insta
 ---
 
 *Review conducted with parallel subagent analysis, adversarial verification, independent line-level re-verification of all critical/major findings, and dynamic AppTest execution. Two subagent findings were refuted during verification and are documented above rather than silently dropped.*
+
+---
+
+## 2026-07 · Feature-engineering state drift, split guardrail, strategy-aware CV
+
+Triggered by a real training crash on the NHANES demo dataset:
+`Training failed: Some column names are not columns of the dataframe:
+{'meds_hbp_has_data', 'meds_chol_has_data'}`.
+
+**Root cause (audited across pages 03–06 + session_state).** Engineered
+columns (here, `*_has_data` missingness indicators) can leave the data and the
+feature list while a downstream reference to them survives:
+- **Feature Selection apply** (`04:440`, `04:483`) updated `selected_features`
+  but never invalidated the per-model preprocessing pipelines built on the old
+  set. Selection drops the low-signal indicators → the split succeeds (clean
+  list) but the stored `ColumnTransformer` still names them and crashes at
+  `fit()`. *This was the reported bug.* Fixed: both handlers now call
+  `reset_downstream_results(clear_feature_engineering=False,
+  clear_feature_selection=False)` — a new flag that clears stale
+  pipelines/splits/models while preserving the selection just made.
+- **Skip** (`03`) only popped `df_engineered`, leaving `selected_features` and
+  pipelines referencing engineered columns — could crash, or worse, silently
+  train on the engineered data the user chose to discard. **Reset** never
+  restored `selected_features`. Both now route through
+  `reset_downstream_results`, restoring the pre-FE list and clearing the full
+  downstream set.
+
+**Backstop (defence in depth).** `pages/06` reconciles the feature list vs the
+data before Prepare Splits, and rebuilds any preprocessing pipeline whose
+columns drifted before `fit()` (`ml.pipeline.reconcile_pipeline_columns`) —
+loud warning, self-heal, never a cryptic crash. Any future drift path degrades
+gracefully.
+
+**Also fixed:** polynomial features skip duplicate names (running twice created
+duplicate labels that broke selection); the math-transform log line stranded
+after `st.rerun()` is recorded again.
+
+**Test-set slider guardrail.** Under the lockbox, the Train & Compare `Test %`
+slider is now disabled and pinned to the lockbox fraction (Train/Val divide the
+remainder), so a live control can never contradict the actual held-out set.
+Group/time splits (which draw their own test set) keep the slider live and say
+so.
+
+**Strategy-aware cross-validation.** CV previously used shuffled KFold
+regardless of the split. A group split (longitudinal) or time split now gets
+GroupKFold/StratifiedGroupKFold / TimeSeriesSplit, so CV can't leak across
+entities or time and inflate the score. CV still runs on training rows only;
+`cv_strategy`/`cv_groups_train` are recorded at split time and cleared with the
+split.
+
+Tests: `tests/test_feature_drift.py` (reconcile backstop + both invalidation
+contracts + the reported crash), `tests/test_cv_strategies.py` (group/time/
+standard fold schemes, fold clamping, graceful fallback). Full suite: 605
+passed, 4 skipped (the 14 `scripts/integration_test.py` errors are pre-existing
+missing-Playwright-`page`-fixture setup errors, not regressions).

--- a/ml/eval.py
+++ b/ml/eval.py
@@ -100,43 +100,77 @@ def perform_cross_validation(
     y: np.ndarray,
     cv_folds: int = 5,
     task_type: str = 'regression',
-    scoring: Optional[str] = None
+    scoring: Optional[str] = None,
+    cv_strategy: str = 'standard',
+    groups: Optional[np.ndarray] = None,
 ) -> Dict[str, np.ndarray]:
     """
-    Perform k-fold cross-validation.
-    
+    Perform k-fold cross-validation, matching the fold scheme to the split.
+
+    The CV strategy must respect the same leakage semantics as the train/test
+    split, or the CV score is optimistically biased:
+    - 'group': the split kept each entity's rows together (longitudinal /
+      repeated measures). Random KFold would put the same entity on both sides
+      of a fold, so use GroupKFold (StratifiedGroupKFold for classification).
+    - 'time': the split was chronological. Random KFold would train on the
+      future to predict the past, so use TimeSeriesSplit (no shuffle). X is
+      assumed to be in chronological order (page 06 supplies it so).
+    - 'standard' (default): StratifiedKFold (classification) / KFold.
+
     Args:
         model: Model with fit/predict interface
-        X: Features
+        X: Features (training rows only — the lockbox test never enters CV)
         y: Targets
         cv_folds: Number of folds
         task_type: 'regression' or 'classification'
         scoring: Scoring metric (if None, uses default for task type)
-        
+        cv_strategy: 'standard' | 'group' | 'time'
+        groups: entity labels aligned to X rows (required for 'group')
+
     Returns:
-        Dictionary with metric arrays across folds
+        Dictionary with metric arrays across folds, plus the strategy used.
     """
     if scoring is None:
         scoring = 'neg_mean_squared_error' if task_type == 'regression' else 'accuracy'
-    
-    # Choose CV strategy
-    if task_type == 'classification':
+
+    strat = (cv_strategy or 'standard').lower()
+    cv_groups = None  # passed through to cross_val_score for group schemes
+
+    if strat == 'group' and groups is not None and len(np.unique(groups)) >= 2:
+        # Never ask for more folds than there are groups.
+        n_splits = max(2, min(cv_folds, int(len(np.unique(groups)))))
+        cv = None
+        if task_type == 'classification':
+            try:
+                from sklearn.model_selection import StratifiedGroupKFold
+                cv = StratifiedGroupKFold(n_splits=n_splits, shuffle=True, random_state=42)
+            except ImportError:
+                cv = None
+        if cv is None:
+            from sklearn.model_selection import GroupKFold
+            cv = GroupKFold(n_splits=n_splits)
+        cv_groups = groups
+    elif strat == 'time':
+        from sklearn.model_selection import TimeSeriesSplit
+        cv = TimeSeriesSplit(n_splits=cv_folds)
+    elif task_type == 'classification':
         cv = StratifiedKFold(n_splits=cv_folds, shuffle=True, random_state=42)
     else:
         cv = KFold(n_splits=cv_folds, shuffle=True, random_state=42)
-    
-    # Perform CV
-    scores = cross_val_score(model, X, y, cv=cv, scoring=scoring, n_jobs=-1)
-    
+
+    scores = cross_val_score(model, X, y, cv=cv, scoring=scoring, n_jobs=-1,
+                             groups=cv_groups)
+
     # Convert to positive if using negative MSE
     if 'neg_' in scoring:
         scores = -scores
-    
+
     return {
         'scores': scores,
         'mean': float(np.mean(scores)),
         'std': float(np.std(scores)),
-        'folds': cv_folds
+        'folds': int(getattr(cv, 'n_splits', cv_folds)),
+        'strategy': strat,
     }
 
 

--- a/ml/pipeline.py
+++ b/ml/pipeline.py
@@ -499,3 +499,59 @@ def _preprocessor_names_fallback(preprocessor, original_feature_names: List[str]
                     out.extend([f"{c}_encoded" for c in columns])
                     break
     return out
+
+
+def reconcile_pipeline_columns(pipe, available_columns):
+    """Trim a preprocessing pipeline's column selectors to columns that exist.
+
+    A stored preprocessing pipeline names its input columns explicitly (the
+    ColumnTransformer keeps ``(name, transformer, [col, ...])`` tuples). If the
+    feature set later changes — e.g. Feature Selection drops an engineered
+    ``*_has_data`` indicator after the pipeline was built — fitting that stale
+    pipeline raises ``ValueError: Some column names are not columns of the
+    dataframe``. This returns an *unfitted* copy whose selectors reference only
+    columns present in ``available_columns``, plus the list of dropped names, so
+    a caller can rebuild-and-warn instead of crashing.
+
+    Returns ``(new_pipe, dropped)``. ``new_pipe is pipe`` (unchanged) when
+    nothing needed dropping. Transformers left with no columns are removed.
+    """
+    from sklearn.base import clone
+
+    available = set(available_columns)
+    dropped: List[str] = []
+
+    def _fix_ct(ct: ColumnTransformer) -> ColumnTransformer:
+        new_transformers = []
+        for name, trans, cols in ct.transformers:
+            if isinstance(cols, (list, tuple)):
+                kept = [c for c in cols if c in available]
+                dropped.extend([c for c in cols if c not in available])
+                if kept:
+                    new_transformers.append((name, clone(trans), kept))
+                # a transformer with no surviving columns is dropped entirely
+            else:
+                new_transformers.append((name, clone(trans), cols))
+        return ColumnTransformer(
+            transformers=new_transformers,
+            remainder=ct.remainder,
+            sparse_threshold=ct.sparse_threshold,
+            n_jobs=ct.n_jobs,
+            transformer_weights=ct.transformer_weights,
+            verbose_feature_names_out=getattr(ct, "verbose_feature_names_out", True),
+        )
+
+    if isinstance(pipe, ColumnTransformer):
+        fixed = _fix_ct(pipe)
+        return (pipe, []) if not dropped else (fixed, dropped)
+
+    if isinstance(pipe, Pipeline):
+        new_steps = []
+        for sname, step in pipe.steps:
+            if isinstance(step, ColumnTransformer):
+                new_steps.append((sname, _fix_ct(step)))
+            else:
+                new_steps.append((sname, clone(step)))
+        return (pipe, []) if not dropped else (Pipeline(new_steps), dropped)
+
+    return pipe, []

--- a/pages/03_Feature_Engineering.py
+++ b/pages/03_Feature_Engineering.py
@@ -18,7 +18,7 @@ from sklearn.decomposition import PCA
 import warnings
 warnings.filterwarnings('ignore')
 
-from utils.session_state import get_data, init_session_state, log_methodology
+from utils.session_state import get_data, init_session_state, log_methodology, reset_downstream_results
 from utils.theme import inject_custom_css, render_guidance, render_sidebar_workflow
 from utils.storyline import render_breadcrumb, render_page_navigation
 
@@ -164,46 +164,25 @@ with col1:
     st.markdown("**Choose whether to engineer features or skip this step:**")
 with col2:
     if st.button("🔄 Reset", help="Clear all engineered features and start over", type="secondary"):
+        # Route the full cascade through the single source of truth: this drops
+        # df_engineered, restores the pre-FE feature list into BOTH selected_features
+        # and data_config.feature_cols, and clears every downstream result
+        # (pipelines, splits, models, analyses) that referenced engineered columns.
         st.session_state.fe_reset_requested = True
-        st.session_state.pop("df_engineered", None)
-        st.session_state["feature_engineering_applied"] = False
-        st.session_state.pop("engineered_feature_names", None)
-        st.session_state.pop("engineering_log", None)
+        reset_downstream_results(clear_feature_engineering=True)
         st.session_state.pop("engineered_feature_transforms", None)
-        # Restore original feature_cols so downstream pages don't
-        # reference columns that no longer exist
-        pre_fe = st.session_state.pop("pre_fe_feature_cols", None)
-        if pre_fe is not None and data_config is not None:
-            data_config.feature_cols = pre_fe
-        # Cascade: clear downstream state that may reference engineered columns
-        st.session_state.pop("feature_selection_results", None)
-        st.session_state.pop("consensus_features", None)
-        st.session_state["preprocessing_pipeline"] = None
-        st.session_state["preprocessing_config"] = None
-        st.session_state["preprocessing_pipelines_by_model"] = {}
-        st.session_state["preprocessing_config_by_model"] = {}
-        st.session_state["trained_models"] = {}
-        st.session_state["model_results"] = {}
-        st.session_state["fitted_estimators"] = {}
-        st.session_state["fitted_preprocessing_pipelines"] = {}
-        st.session_state["X_train"] = None
-        st.session_state["X_val"] = None
-        st.session_state["X_test"] = None
-        st.session_state["y_train"] = None
-        st.session_state["y_val"] = None
-        st.session_state["y_test"] = None
-        st.session_state["permutation_importance"] = {}
-        st.session_state["partial_dependence"] = {}
-        st.session_state["shap_results"] = {}
-        st.session_state.pop("sensitivity_seed_results", None)
-        st.session_state["report_data"] = None
         st.rerun()
 with col3:
     if st.button("⏭️ Skip", help="Recommended for most first passes: continue with your original features"):
         st.info("✅ Skipped feature engineering. Proceeding with your original features — this is the recommended first pass for many projects.")
-        # Make sure no engineered features are in session state
-        st.session_state.pop("df_engineered", None)
-        st.session_state["feature_engineering_applied"] = False
+        # Skip must actually revert to the original features. Previously it only
+        # popped df_engineered, leaving selected_features and any preprocessing
+        # pipeline still referencing engineered columns — which then either
+        # crashed at training or, worse, silently trained on the very engineered
+        # data the user chose to discard. Route through the canonical resetter so
+        # the original feature list is restored and all stale downstream state is
+        # cleared.
+        reset_downstream_results(clear_feature_engineering=True)
         st.success("👉 Continue to **Feature Selection** ")
         st.stop()
 
@@ -340,16 +319,26 @@ with _fe_tabs[0]:
                 X_poly = poly.fit_transform(X_numeric)
                 poly_feature_names = poly.get_feature_names_out(numeric_features)
                 
-                # Remove original features (they're duplicated)
-                new_cols = [name for name in poly_feature_names if name not in numeric_features]
-                new_indices = [i for i, name in enumerate(poly_feature_names) if name not in numeric_features]
-                
+                # Remove original features (they're duplicated), and skip any
+                # polynomial name that already exists — running this twice would
+                # otherwise create duplicate column labels that later break
+                # column-based selection (ColumnTransformer / df[cols]).
+                _existing = set(X_engineered.columns)
+                new_cols = [name for name in poly_feature_names
+                            if name not in numeric_features and name not in _existing]
+                new_indices = [i for i, name in enumerate(poly_feature_names)
+                               if name not in numeric_features and name not in _existing]
+                _skipped_dupes = sum(1 for name in poly_feature_names
+                                     if name not in numeric_features and name in _existing)
+
                 X_poly_new = X_poly[:, new_indices]
                 poly_df = pd.DataFrame(X_poly_new, columns=new_cols, index=X_engineered.index)
-                
+
                 X_engineered = pd.concat([X_engineered, poly_df], axis=1)
                 engineered_features.extend(new_cols)
                 engineering_log.append(f"Polynomial degree {poly_degree} ({'interaction-only' if interaction_only else 'full'}): +{len(new_cols)} features")
+                if _skipped_dupes:
+                    st.caption(f"Skipped {_skipped_dupes} polynomial feature(s) that already existed.")
                 
                 # Save back to session state
                 st.session_state.fe_work_in_progress['X_engineered'] = X_engineered
@@ -492,11 +481,13 @@ with _fe_tabs[1]:
                     
                     engineered_features.extend(new_cols)
                     
+                    engineering_log.append(f"Mathematical transforms: +{len(new_cols)} features")
+
                     # Save back to session state
                     st.session_state.fe_work_in_progress["X_engineered"] = X_engineered
                     st.session_state.fe_work_in_progress["engineered_features"] = engineered_features
                     st.session_state.fe_work_in_progress["engineering_log"] = engineering_log
-                    
+
                     # Resolve skew insight if all skewed features have been transformed
                     # Resolve skew insight with structured details
                     _skew_ins = _fe_ledger.get("eda_skew_group")
@@ -515,10 +506,9 @@ with _fe_tabs[1]:
                                 },
                             )
                     
-                    st.rerun()
-                    engineering_log.append(f"Mathematical transforms: +{len(new_cols)} features")
                     st.success(f"✅ Created **{len(new_cols)} transformed features**")
-                    
+                    st.rerun()
+
                 except Exception as e:
                     st.error(f"❌ Error: {e}")
 

--- a/pages/04_Feature_Selection.py
+++ b/pages/04_Feature_Selection.py
@@ -14,7 +14,7 @@ import pandas as pd
 import numpy as np
 from typing import List, Dict
 
-from utils.session_state import init_session_state, get_data, DataConfig, log_methodology
+from utils.session_state import init_session_state, get_data, DataConfig, log_methodology, reset_downstream_results
 from utils.storyline import render_breadcrumb, render_page_navigation
 from utils.theme import inject_custom_css, render_guidance, render_reviewer_concern, render_step_indicator, render_sidebar_workflow
 from utils.table_export import table
@@ -440,6 +440,12 @@ if results:
             data_config.feature_cols = consensus
             st.session_state['data_config'] = data_config
             st.session_state['selected_features'] = list(consensus)
+            # The feature set changed: any preprocessing pipeline, split, or
+            # trained model built on the old set is stale and would name dropped
+            # columns at train time. Clear them (keeping this selection and its
+            # record) so Preprocess rebuilds against the new set.
+            reset_downstream_results(clear_feature_engineering=False,
+                                     clear_feature_selection=False)
             # Retrieve consensus_threshold from the analysis log
             consensus_threshold_logged = None
             for entry in st.session_state.get('methodology_log', []):
@@ -483,6 +489,10 @@ if results:
             data_config.feature_cols = manual_selection
             st.session_state['data_config'] = data_config
             st.session_state['selected_features'] = list(manual_selection)
+            # Feature set changed → clear stale pipelines/splits/models built on
+            # the old set (keeping this selection and its record).
+            reset_downstream_results(clear_feature_engineering=False,
+                                     clear_feature_selection=False)
             log_methodology(step='Feature Selection Applied', action='Applied manual feature selection', details={
                 'method': 'manual',
                 'n_features_selected': len(manual_selection),

--- a/pages/06_Train_and_Compare.py
+++ b/pages/06_Train_and_Compare.py
@@ -317,6 +317,26 @@ if st.button("Prepare Splits", type="primary"):
         target_col = data_config.target_col
         feature_cols = st.session_state.get('selected_features') or data_config.feature_cols
 
+        # Reconcile the feature list against the actual data. If features were
+        # engineered and later dropped (e.g. Feature Selection or a Reset/Skip
+        # removed an engineered column), the stored list can name columns that
+        # no longer exist — blindly indexing would raise a cryptic KeyError.
+        _missing_fc = [c for c in feature_cols if c not in df.columns]
+        if _missing_fc:
+            feature_cols = [c for c in feature_cols if c in df.columns]
+            st.warning(
+                f"⚠️ {len(_missing_fc)} selected feature(s) are no longer in the "
+                f"data and were dropped: {', '.join(map(str, _missing_fc[:8]))}"
+                f"{'…' if len(_missing_fc) > 8 else ''}. This happens when features "
+                f"were engineered and later removed. Re-visit Preprocess to reconfigure."
+            )
+        if not feature_cols:
+            st.error(
+                "None of the selected features exist in the current data. "
+                "Re-run Feature Selection (or Skip it) before training."
+            )
+            st.stop()
+
         X = df[feature_cols].copy()
         y = df[target_col].copy()
         mask = y.notna()
@@ -1204,6 +1224,26 @@ def _train_models(models_to_train, selected_model_params, use_optimization=False
                 if model_pipeline is None:
                     st.error("Preprocessing pipeline not found for this model.")
                     continue
+
+                # Backstop: a preprocessing pipeline built on a since-changed
+                # feature set still names its old columns and would crash at
+                # fit() ("Some column names are not columns of the dataframe").
+                # Rebuild it against the columns actually present, dropping the
+                # stale ones, so a state drift self-heals loudly instead of
+                # failing the whole run.
+                if isinstance(X_train, pd.DataFrame):
+                    from ml.pipeline import reconcile_pipeline_columns
+                    model_pipeline, _dropped_cols = reconcile_pipeline_columns(
+                        model_pipeline, X_train.columns
+                    )
+                    if _dropped_cols:
+                        st.warning(
+                            f"⚠️ {model_name.upper()}'s preprocessing referenced "
+                            f"features no longer in the data "
+                            f"({', '.join(map(str, _dropped_cols[:8]))}"
+                            f"{'…' if len(_dropped_cols) > 8 else ''}) and was rebuilt "
+                            f"without them. Re-run Preprocess to reconfigure intentionally."
+                        )
 
                 # Fit preprocessing on training data only
                 model_pipeline.fit(X_train)

--- a/pages/06_Train_and_Compare.py
+++ b/pages/06_Train_and_Compare.py
@@ -698,7 +698,13 @@ if st.button("Prepare Splits", type="primary"):
         except Exception:
             logger.exception("Failed to record split provenance")
 
-        st.success(f"Splits prepared: Train={len(X_train)}, Val={len(X_val)}, Test={len(X_test)}")
+        _n_tr, _n_va, _n_te = len(X_train), len(X_val), len(X_test)
+        _n_all = max(1, _n_tr + _n_va + _n_te)
+        st.success(
+            f"✅ Splits ready — Train {_n_tr:,} ({_n_tr/_n_all:.0%}) · "
+            f"Val {_n_va:,} ({_n_va/_n_all:.0%}) · Test {_n_te:,} ({_n_te/_n_all:.0%})"
+        )
+        st.caption("Train fits each model · Validation tunes it · Test is scored once, at the end.")
         # Guardrails for small evaluation sets
         if len(X_test) < 5:
             st.error(

--- a/pages/06_Train_and_Compare.py
+++ b/pages/06_Train_and_Compare.py
@@ -193,29 +193,48 @@ train_size_default = int((split_config_existing.train_size * 100) if split_confi
 val_size_default = int((split_config_existing.val_size * 100) if split_config_existing and split_config_existing.val_size else 15)
 test_size_default = int((split_config_existing.test_size * 100) if split_config_existing and split_config_existing.test_size else 15)
 
+# The upload lockbox owns the test set for random/stratified splits (group and
+# time splits draw their own, disclosed at split time). When it governs, lock
+# the Test % control to the lockbox fraction so a live slider can never
+# contradict the actual held-out set — the source of a subtle "why didn't that
+# do anything?" confusion.
+from utils.test_lockbox import get_lockbox as _slider_get_lockbox, is_exploratory as _slider_is_exploratory
+_slider_lb = None if _slider_is_exploratory() else _slider_get_lockbox()
+_test_governed_by_lockbox = _slider_lb is not None and not use_group_split and not use_time_split
+
 with col1:
     train_size = st.slider("Train %", 50, 90, train_size_default, key="train_split_train_pct") / 100
 with col2:
     val_size = st.slider("Val %", 5, 30, val_size_default, key="train_split_val_pct") / 100
 with col3:
-    test_size = st.slider("Test %", 5, 30, test_size_default, key="train_split_test_pct") / 100
+    if _test_governed_by_lockbox:
+        _lb_pct = int(round(_slider_lb['fraction'] * 100))
+        st.slider("Test %", 5, 30, min(max(_lb_pct, 5), 30), disabled=True,
+                  key="train_split_test_pct_locked",
+                  help="Fixed at upload by the test-set lockbox. Change it on Upload & Audit.")
+        test_size = float(_slider_lb['fraction'])
+    else:
+        test_size = st.slider("Test %", 5, 30, test_size_default, key="train_split_test_pct") / 100
 
-# Under the lockbox the test fraction is fixed at upload; the Test % slider
-# above only matters for group/time splits (which bypass the lockbox) or when
-# no lockbox exists. Say so rather than leaving a silently dead control.
-from utils.test_lockbox import get_lockbox as _slider_get_lockbox, is_exploratory as _slider_is_exploratory
-_slider_lb = None if _slider_is_exploratory() else _slider_get_lockbox()
-if _slider_lb is not None:
+if _test_governed_by_lockbox:
     st.caption(
-        f"🔒 The held-out test fraction is governed by the upload lockbox "
-        f"({_slider_lb['fraction']:.0%}, n={_slider_lb['n_test']}) — for random/stratified "
-        f"splits the Test % slider is ignored and Train/Val set only their relative sizes. "
-        f"Change the holdout on Upload & Audit."
+        f"🔒 Test set is locked at {test_size:.0%} (n={_slider_lb['n_test']}) by the upload "
+        f"lockbox — held out since before feature engineering. Train % and Val % divide the "
+        f"remaining {1 - test_size:.0%}. Change the holdout on Upload & Audit."
     )
-
-if abs(train_size + val_size + test_size - 1.0) > 0.01:
-    st.error("Splits must sum to 100%")
-    st.stop()
+    if abs(train_size + val_size - (1.0 - test_size)) > 0.01:
+        st.error(f"With the lockbox holding out {test_size:.0%} for test, "
+                 f"Train % + Val % must sum to {1.0 - test_size:.0%}.")
+        st.stop()
+else:
+    if _slider_lb is not None:
+        st.caption(
+            f"🔒 A {_slider_lb['fraction']:.0%} lockbox test set exists, but this "
+            f"group/time split draws its own test set instead (disclosed at split time)."
+        )
+    if abs(train_size + val_size + test_size - 1.0) > 0.01:
+        st.error("Splits must sum to 100%")
+        st.stop()
 
 split_config = SplitConfig(
     train_size=train_size,
@@ -450,6 +469,13 @@ if st.button("Prepare Splits", type="primary"):
         else:
             st.session_state.pop("target_label_encoder", None)
         
+        # Record which CV scheme the fold logic must use to match this split's
+        # leakage semantics (see ml.eval.perform_cross_validation). Cross-
+        # validation runs on TRAINING ROWS ONLY, so group labels are captured
+        # for the train rows alone.
+        st.session_state['cv_strategy'] = 'standard'
+        st.session_state['cv_groups_train'] = None
+
         # Split data (group-based, time-based, or random)
         if use_group_split and entity_id_final:
             groups = to_numpy_1d(df.iloc[original_indices][entity_id_final])
@@ -457,6 +483,9 @@ if st.button("Prepare Splits", type="primary"):
 
             gss = GroupShuffleSplit(n_splits=1, test_size=(val_size + test_size), random_state=split_config.random_state)
             train_idx, temp_idx = next(gss.split(indices, y_arr, groups))
+            # Same-entity rows must stay together in CV too, or folds leak.
+            st.session_state['cv_strategy'] = 'group'
+            st.session_state['cv_groups_train'] = groups[train_idx]
 
             groups_temp = groups[temp_idx]
             rel_val = val_size / (val_size + test_size)
@@ -475,6 +504,8 @@ if st.button("Prepare Splits", type="primary"):
             n_test_groups = len(np.unique(groups[temp_idx[test_idx]]))
             st.info(f"Group-based split: {n_train_groups} train groups, {n_val_groups} val groups, {n_test_groups} test groups")
         elif split_config.use_time_split and data_config.datetime_col:
+            # Chronological split → CV must respect time order too (no shuffle).
+            st.session_state['cv_strategy'] = 'time'
             df_work = df.iloc[original_indices].copy()
             df_work["_temp_index"] = np.arange(len(df_work))
             df_work = df_work.sort_values(data_config.datetime_col)
@@ -1487,7 +1518,9 @@ def _train_models(models_to_train, selected_model_params, use_optimization=False
                         _cv_full = make_cv_pipeline(model_pipeline, _cv_estimator)
                         cv_results = perform_cross_validation(
                             _cv_full, X_train, _cv_y_train,
-                            cv_folds=cv_folds, task_type=data_config.task_type
+                            cv_folds=cv_folds, task_type=data_config.task_type,
+                            cv_strategy=st.session_state.get('cv_strategy', 'standard'),
+                            groups=st.session_state.get('cv_groups_train'),
                         )
                     except Exception as cv_error:
                         st.warning(f"Cross-validation failed for {model_name}: {cv_error}. Skipping CV.")

--- a/tests/test_cv_strategies.py
+++ b/tests/test_cv_strategies.py
@@ -1,0 +1,86 @@
+"""Cross-validation must respect the split's leakage semantics.
+
+If the train/test split kept entities together (group split) or in time order
+(time split), plain shuffled KFold would leak across folds and inflate the CV
+score. perform_cross_validation adapts the fold scheme to cv_strategy.
+"""
+import os
+import sys
+
+import numpy as np
+import pytest
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, PROJECT_ROOT)
+
+from sklearn.linear_model import LinearRegression, LogisticRegression  # noqa: E402
+
+
+def test_standard_strategy_matches_task():
+    from ml.eval import perform_cross_validation
+    X = np.random.RandomState(0).rand(60, 3)
+    y = X[:, 0] * 2 + np.random.RandomState(1).rand(60) * 0.1
+    res = perform_cross_validation(LinearRegression(), X, y, cv_folds=5,
+                                   task_type='regression')
+    assert res['strategy'] == 'standard'
+    assert res['folds'] == 5
+    assert np.isfinite(res['mean'])
+
+
+def test_group_strategy_uses_group_folds_and_clamps():
+    """Group CV must not leak entities across folds and must not request more
+    folds than there are groups."""
+    from ml.eval import perform_cross_validation
+    rng = np.random.RandomState(0)
+    # 4 entities, repeated measures — a random KFold would split an entity
+    groups = np.repeat(np.arange(4), 10)
+    X = rng.rand(40, 3)
+    y = X[:, 0] + rng.rand(40) * 0.1
+    res = perform_cross_validation(LinearRegression(), X, y, cv_folds=5,
+                                   task_type='regression',
+                                   cv_strategy='group', groups=groups)
+    assert res['strategy'] == 'group'
+    # 5 folds requested but only 4 groups → clamped
+    assert res['folds'] == 4
+    assert np.isfinite(res['mean'])
+
+
+def test_group_strategy_falls_back_when_no_groups():
+    from ml.eval import perform_cross_validation
+    X = np.random.RandomState(0).rand(40, 3)
+    y = X[:, 0] + np.random.RandomState(1).rand(40) * 0.1
+    # cv_strategy='group' but groups omitted → must not crash; uses standard
+    res = perform_cross_validation(LinearRegression(), X, y, cv_folds=4,
+                                   task_type='regression',
+                                   cv_strategy='group', groups=None)
+    assert np.isfinite(res['mean'])
+
+
+def test_time_strategy_uses_timeseries_split():
+    from ml.eval import perform_cross_validation
+    rng = np.random.RandomState(0)
+    n = 60
+    X = np.column_stack([np.arange(n), rng.rand(n)])  # first col is time-like
+    y = np.arange(n) * 0.5 + rng.rand(n)
+    res = perform_cross_validation(LinearRegression(), X, y, cv_folds=5,
+                                   task_type='regression', cv_strategy='time')
+    assert res['strategy'] == 'time'
+    assert res['folds'] == 5
+    assert np.isfinite(res['mean'])
+
+
+def test_group_classification_keeps_groups_intact():
+    from ml.eval import perform_cross_validation
+    rng = np.random.RandomState(0)
+    groups = np.repeat(np.arange(6), 10)
+    X = rng.rand(60, 3)
+    y = (rng.rand(60) > 0.5).astype(int)
+    res = perform_cross_validation(LogisticRegression(max_iter=200), X, y,
+                                   cv_folds=4, task_type='classification',
+                                   cv_strategy='group', groups=groups)
+    assert res['strategy'] == 'group'
+    assert np.isfinite(res['mean'])
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/tests/test_feature_drift.py
+++ b/tests/test_feature_drift.py
@@ -1,0 +1,138 @@
+"""Regression tests for the feature-engineering column-drift bug class.
+
+A user hit `Training failed: Some column names are not columns of the
+dataframe: {'meds_hbp_has_data', 'meds_chol_has_data'}` — an engineered
+missingness indicator was created, a preprocessing pipeline was built naming
+it, then Feature Selection dropped that low-signal column, leaving the stored
+pipeline referencing a column no longer in the data. It only surfaced at
+`ColumnTransformer.fit()`.
+
+These pin the fixes:
+- ml.pipeline.reconcile_pipeline_columns rebuilds a pipeline against the
+  columns that actually exist (the training backstop).
+- reset_downstream_results(clear_feature_selection=False) invalidates stale
+  pipelines/splits/models when Feature Selection is applied, without wiping
+  the selection just made.
+- reset_downstream_results(clear_feature_engineering=True) restores the
+  pre-FE feature list (the Skip/Reset fix).
+"""
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+import pytest
+import streamlit as st
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, PROJECT_ROOT)
+
+
+def _clear_session():
+    for k in list(st.session_state.keys()):
+        del st.session_state[k]
+
+
+# ── The training backstop: reconcile a stale pipeline against real columns ──
+
+class TestReconcilePipelineColumns:
+    def _stale_pipeline(self):
+        from ml.pipeline import build_preprocessing_pipeline
+        # Built when the engineered indicator still existed
+        return build_preprocessing_pipeline(
+            numeric_features=["age", "bmi", "meds_hbp_has_data"],
+            categorical_features=[],
+            random_state=42,
+        )
+
+    def test_stale_pipeline_crashes_without_reconcile(self):
+        """Documents the exact reported failure so the fix stays honest."""
+        X_train = pd.DataFrame({"age": [40.0, 55, 60, 33, 70],
+                                "bmi": [22.1, 28.4, 31.0, 24.5, 26.6]})
+        with pytest.raises(ValueError, match="not columns of the dataframe"):
+            self._stale_pipeline().fit(X_train)
+
+    def test_reconcile_drops_missing_and_fits(self):
+        from ml.pipeline import reconcile_pipeline_columns
+        X_train = pd.DataFrame({"age": [40.0, 55, 60, 33, 70],
+                                "bmi": [22.1, 28.4, 31.0, 24.5, 26.6]})
+        healed, dropped = reconcile_pipeline_columns(self._stale_pipeline(),
+                                                     X_train.columns)
+        assert dropped == ["meds_hbp_has_data"]
+        # The reported crash no longer happens; the surviving columns transform.
+        out = healed.fit_transform(X_train)
+        assert out.shape == (5, 2)
+
+    def test_reconcile_is_noop_when_columns_intact(self):
+        from ml.pipeline import reconcile_pipeline_columns
+        from ml.pipeline import build_preprocessing_pipeline
+        pipe = build_preprocessing_pipeline(numeric_features=["age", "bmi"],
+                                            categorical_features=[], random_state=42)
+        same, dropped = reconcile_pipeline_columns(pipe, ["age", "bmi", "extra"])
+        assert same is pipe and dropped == []
+
+
+# ── The invalidation contracts ──
+
+class TestFeatureChangeInvalidation:
+    def setup_method(self):
+        _clear_session()
+
+    def teardown_method(self):
+        _clear_session()
+
+    def test_applying_feature_selection_clears_stale_pipeline(self):
+        """Feature Selection applied → stored preprocessing pipelines/splits/
+        models must be cleared (they named the old feature set), but the
+        selection results themselves must survive."""
+        from utils.session_state import reset_downstream_results
+
+        st.session_state["preprocessing_pipelines_by_model"] = {"ridge": "STALE"}
+        st.session_state["preprocessing_config_by_model"] = {"ridge": "STALE"}
+        st.session_state["X_train"] = "STALE"
+        st.session_state["trained_models"] = {"ridge": "STALE"}
+        st.session_state["feature_selection_results"] = {"keep": "ME"}
+        st.session_state["consensus_features"] = ["age", "bmi"]
+
+        reset_downstream_results(clear_feature_engineering=False,
+                                 clear_feature_selection=False)
+
+        # Stale modelling artifacts gone
+        assert st.session_state.get("preprocessing_pipelines_by_model") == {}
+        assert st.session_state.get("preprocessing_config_by_model") == {}
+        assert st.session_state.get("X_train") is None
+        assert st.session_state.get("trained_models") == {}
+        # The selection just applied survives
+        assert st.session_state.get("feature_selection_results") == {"keep": "ME"}
+        assert st.session_state.get("consensus_features") == ["age", "bmi"]
+
+    def test_default_reset_still_clears_feature_selection(self):
+        """The data-change path (default flags) must keep clearing FS results."""
+        from utils.session_state import reset_downstream_results
+        st.session_state["feature_selection_results"] = {"marker": "STALE"}
+        st.session_state["consensus_features"] = ["x"]
+        reset_downstream_results()
+        assert st.session_state.get("feature_selection_results") is None
+        assert st.session_state.get("consensus_features") is None
+
+    def test_skip_reset_restores_pre_fe_features(self):
+        """Skip/Reset route through reset_downstream_results(clear_feature_
+        engineering=True), which must restore the pre-FE selection into
+        selected_features (Reset previously left the engineered list, so
+        downstream still referenced dropped columns)."""
+        from utils.session_state import reset_downstream_results
+
+        st.session_state["pre_fe_feature_cols"] = ["age", "bmi"]
+        st.session_state["selected_features"] = ["age", "bmi", "meds_hbp_has_data"]
+        st.session_state["df_engineered"] = pd.DataFrame({"age": [1.0]})
+        st.session_state["feature_engineering_applied"] = True
+
+        reset_downstream_results(clear_feature_engineering=True)
+
+        assert st.session_state.get("selected_features") == ["age", "bmi"]
+        assert st.session_state.get("df_engineered") is None
+        assert st.session_state.get("feature_engineering_applied") is False
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/utils/session_state.py
+++ b/utils/session_state.py
@@ -263,13 +263,20 @@ def set_data(df: pd.DataFrame, is_schema_change: Optional[bool] = None):
 
 
 def reset_downstream_results(clear_feature_engineering: bool = True,
-                             restore_pre_fe_features: bool = True):
+                             restore_pre_fe_features: bool = True,
+                             clear_feature_selection: bool = True):
     """Clear every RESULT computed from the current data, keeping configuration.
 
     Single source of truth for downstream invalidation — used by
     reset_data_dependent_state() (full data change), set_data() (same-schema
     content change), and Page 01 (feature/target/task change). Any page that
     introduces a new result key must add it here.
+
+    clear_feature_selection=False preserves the feature-selection results,
+    consensus list, and its provenance/ledger entries. Feature Selection uses
+    this when it APPLIES a new selection: the pipelines/splits/models built on
+    the old feature set are stale and must go, but the selection just made (and
+    its record) must survive.
     """
     # Feature engineering (df_engineered would otherwise keep serving stale
     # data through get_data()'s precedence)
@@ -321,12 +328,14 @@ def reset_downstream_results(clear_feature_engineering: bool = True,
     st.session_state.explainability_robustness = {}
     st.session_state.eda_results = {}
     st.session_state.eda_insights = []
-    for key in ("shap_results", "shap_matplotlib_figs", "bootstrap_results",
-                "baseline_results", "calibration_results",
-                "sensitivity_seed_results", "hypothesis_test_results",
-                "feature_selection_results", "consensus_features",
-                "table1_df", "table1_metadata", "custom_table1_tests",
-                "dataset_profile"):
+    _analysis_keys = ["shap_results", "shap_matplotlib_figs", "bootstrap_results",
+                      "baseline_results", "calibration_results",
+                      "sensitivity_seed_results", "hypothesis_test_results",
+                      "table1_df", "table1_metadata", "custom_table1_tests",
+                      "dataset_profile"]
+    if clear_feature_selection:
+        _analysis_keys += ["feature_selection_results", "consensus_features"]
+    for key in _analysis_keys:
         st.session_state.pop(key, None)
 
     # Report artifacts
@@ -348,8 +357,11 @@ def reset_downstream_results(clear_feature_engineering: bool = True,
     # Downstream provenance sections now describe work that no longer exists
     prov = st.session_state.get("workflow_provenance")
     if prov is not None:
-        for section in ("eda", "feature_selection", "split", "preprocessing",
-                        "training", "explainability", "coach"):
+        _sections = ["eda", "split", "preprocessing",
+                     "training", "explainability", "coach"]
+        if clear_feature_selection:
+            _sections.append("feature_selection")
+        for section in _sections:
             if hasattr(prov, section):
                 setattr(prov, section, None)
         if clear_feature_engineering and hasattr(prov, "feature_engineering"):
@@ -365,12 +377,14 @@ def reset_downstream_results(clear_feature_engineering: bool = True,
     ledger = st.session_state.get("insight_ledger")
     if ledger is not None:
         if hasattr(ledger, "rollback_resolutions"):
-            ledger.rollback_resolutions({
-                "03_Feature_Engineering", "04_Feature_Selection",
+            _rollback_pages = {
                 "05_Preprocess", "06_Train_and_Compare",
                 "07_Explainability", "08_Sensitivity_Analysis",
                 "09_Hypothesis_Testing",
-            })
+            }
+            if clear_feature_selection:
+                _rollback_pages |= {"03_Feature_Engineering", "04_Feature_Selection"}
+            ledger.rollback_resolutions(_rollback_pages)
         if hasattr(ledger, "prune_auto_generated"):
             ledger.prune_auto_generated({
                 "02_EDA", "05_Preprocess", "06_Train_and_Compare",

--- a/utils/session_state.py
+++ b/utils/session_state.py
@@ -311,7 +311,8 @@ def reset_downstream_results(clear_feature_engineering: bool = True,
     st.session_state.feature_names_by_model = {}
     for key in ("train_indices", "val_indices", "test_indices", "split_config",
                 "target_transformer", "target_label_encoder",
-                "y_train_original", "y_val_original", "y_test_original"):
+                "y_train_original", "y_val_original", "y_test_original",
+                "cv_strategy", "cv_groups_train"):
         st.session_state.pop(key, None)
 
     # Models & metrics


### PR DESCRIPTION
Three related Train & Compare correctness fixes, prompted by a real training crash on the NHANES demo data.

## 1. Feature-engineering state drift crashed training (the reported bug)
`Training failed: Some column names are not columns of the dataframe: {'meds_hbp_has_data', 'meds_chol_has_data'}`

An audit across pages 03–06 + `session_state` traced this to engineered columns leaving the data/feature list while a downstream reference to them survived. The crash is the *sklearn* `ValueError` (not a pandas `KeyError`), which pins it to a **stored preprocessing pipeline out of sync with the training columns**:

- **Root cause** — `pages/04` "Apply feature selection" (both consensus and manual) updated the feature list but never invalidated the per-model preprocessing pipelines built on the old set. When selection drops the low-signal `*_has_data` indicators, the split succeeds (clean list) but the stale `ColumnTransformer` still names them and crashes at `fit()`. Now routes through `reset_downstream_results(clear_feature_engineering=False, clear_feature_selection=False)` — a new flag that clears stale pipelines/splits/models while preserving the selection just applied and its provenance.
- **Skip / Reset** — `pages/03` **Skip** only popped `df_engineered`, leaving `selected_features` and pipelines referencing engineered columns (could crash, or silently train on the data the user chose to discard); **Reset** never restored `selected_features`. Both now route through `reset_downstream_results`, restoring the pre-FE list and clearing the full downstream set.
- **Backstop** — `pages/06` reconciles the feature list vs the data before Prepare Splits, and rebuilds any preprocessing pipeline whose columns drifted before `fit()` (`ml.pipeline.reconcile_pipeline_columns`) — a loud, self-healing warning instead of a cryptic crash, so any future drift path degrades gracefully.
- Also: polynomial features skip duplicate names (running twice created duplicate labels that broke selection); the math-transform log line stranded after `st.rerun()` is recorded again.

## 2. Test% slider guardrail
Under the lockbox (random/stratified splits), the Train & Compare **Test %** slider is now disabled and pinned to the lockbox fraction, with Train/Val dividing the remainder — a live control can no longer contradict the actual held-out set. Group/time splits draw their own test set, so they keep the slider live and disclose it.

## 3. Strategy-aware cross-validation
CV used shuffled `KFold` regardless of the split, so a **group split** (longitudinal / repeated measures) or a **time split** would leak across entities or time *inside* CV and inflate the score. `perform_cross_validation` now takes `cv_strategy` + `groups` and selects `GroupKFold`/`StratifiedGroupKFold` or `TimeSeriesSplit`, clamping folds to the number of groups and falling back gracefully when groups are absent. The scheme is recorded at split time (training rows only, cleared with the split). CV still never touches the lockbox test set.

## Verification
- New: `tests/test_feature_drift.py` (reconcile backstop + both invalidation contracts + the reported crash reproduced), `tests/test_cv_strategies.py` (group/time/standard schemes, fold clamping, no-groups fallback).
- Full suite: **605 passed, 4 skipped**. The 14 `scripts/integration_test.py` errors are pre-existing missing-Playwright-`page`-fixture setup errors, not regressions.
- Page-06 AppTests (lockbox split, wide guards, cascade invalidation) green; app boots to HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Y6pZssF946f2jqcuoYKkz

---
_Generated by [Claude Code](https://claude.ai/code/session_016Y6pZssF946f2jqcuoYKkz)_