### PR TITLE
Session restore fidelity (lockbox survives), NaN-safe calibration/CIs, architecture design brief

### DIFF
--- a/docs/ARCHITECTURE_SCROLLYTELLING_BRIEF.md
+++ b/docs/ARCHITECTURE_SCROLLYTELLING_BRIEF.md
@@ -1,0 +1,267 @@
+# Design brief — Tabular ML Lab: a scroll-driven architecture explainer
+
+**For:** a Claude design (Fable 5) session **with access to this repository.**
+**Deliverable:** one self-contained, scroll-animated HTML file that explains, to a
+technically-literate but non-engineer audience (research collaborators,
+reviewers, conference attendees), **(a) how the modeling process works** and
+**(b) how the app's four architectural planes interact.** Animations play as the
+reader scrolls; nothing autoplays off-screen.
+
+This document is the *instruction set*. Follow the content precisely — it is
+grounded in the real code, and you can verify every claim by opening the files
+named below. Treat the visual/motion direction as a strong, opinionated
+starting point and elevate it with your own craft; treat the **architecture
+facts and the honesty theme as non-negotiable.**
+
+---
+
+## 0. Read these first (ground truth — do not paraphrase from memory)
+
+Open and skim these before designing. Every label, arrow, and number in the
+piece must trace to them. If something here disagrees with the code, **the code
+wins** — and flag it.
+
+| Plane / concept | File(s) | Key symbols |
+|---|---|---|
+| **Data plane** | `utils/session_state.py` | `get_data()`, `set_data()`, `reset_downstream_results()`; state keys: `raw_data → df_engineered → selected_features → X_train/X_val/X_test → trained_models → model_results` |
+| **Test-set lockbox** | `utils/test_lockbox.py` | `ensure_lockbox()`, `train_row_mask()`, `is_exploratory()` |
+| **Advisory plane** | `utils/insight_ledger.py` | `class InsightLedger`, `class Insight`; `upsert / resolve / acknowledge / rollback_resolutions / prune_auto_generated` |
+| **Record plane** | `utils/workflow_provenance.py` | `class WorkflowProvenance`; section slots `eda, feature_engineering, feature_selection, split, preprocessing, training, explainability, sensitivity, coach`; `record_*()` methods |
+| **Narrative plane** | `ml/narrative_engine.py` | `class NarrativeEngine`, `class ManuscriptDraft` (evidence map, `[AUTHOR REQUIRED]` scaffolds, ownership preamble) |
+| **Modeling coach** | `ml/model_coach.py`, `ml/coach_probe.py` | `select_top_picks()`, `model_viability()`, `run_probe()`, `run_post_training_diagnostics()` |
+| **The pages (pipeline stages)** | `pages/01…10*.py` | the ten workflow steps, in order |
+| **Prior architecture notes** | `CODE_REVIEW.md` (esp. the "Design principles" and the 2026-07 sections) | the invariants the visualization should embody |
+
+---
+
+## 1. The single idea the piece must land
+
+> **One dataset flows through ten steps; four planes watch that flow and turn it
+> into a manuscript you can defend. The planes never let the story outrun the
+> evidence.**
+
+Two axes carry this:
+
+- **Horizontal axis — the modeling pipeline** (§3): the dataset's linear journey,
+  Upload → … → Manuscript.
+- **Vertical axis — the four planes** (§2): parallel lanes that each stage writes
+  to and reads from. The planes are the app's spine; the pages are just where the
+  user stands.
+
+The payoff is the **honesty machinery** (§4): the lockbox, the invalidation
+cascade, and provenance→manuscript. If a viewer leaves remembering only one
+thing, it should be *"the tool physically cannot claim what it didn't record,
+and it sealed the test set before anyone looked."*
+
+---
+
+## 2. The four planes (the vertical axis) — define each on screen
+
+Render these as **four horizontal lanes**, top to bottom, each with its own accent
+(see §6). Each lane has a fixed identity the reader learns once and then tracks:
+
+1. **Data plane — "the material."** `utils/session_state.py`.
+   The dataframe and everything derived from it: raw table → engineered features →
+   the train/val/test split → fitted models → metrics. This is the only plane that
+   holds the actual numbers. Voice: *concrete, physical.*
+   Reads/writes: every stage. Governed by `set_data()` and `get_data()`'s
+   precedence (`df_engineered > filtered_data > raw_data`).
+
+2. **Advisory plane — "the coach."** `utils/insight_ledger.py`.
+   A ledger of findings: EDA insights, the modeling coach's shortlist and
+   evidence-probe verdicts, preprocessing guards, post-training diagnostics.
+   Findings are *upserted* by producers and *resolved / acknowledged* when the
+   user acts, or *pruned* when their producer re-runs. Voice: *observing, advising —
+   never deciding for you.* It watches the data plane and speaks.
+
+3. **Record plane — "the notary."** `utils/workflow_provenance.py`.
+   An append-only record of what was actually *done* at each step — the split
+   strategy and seed, the preprocessing recipe, which models trained, the coach
+   shortlist that was followed. One typed slot per stage (`eda`, `split`,
+   `training`, …). Voice: *dispassionate, factual.* It does not advise; it testifies.
+
+4. **Narrative plane — "the author's desk."** `ml/narrative_engine.py`.
+   Compiles the record plane into a `ManuscriptDraft`: Methods and Results written
+   from provenance, an **evidence map** (each sentence → its source), an
+   **ownership preamble**, and **`[AUTHOR REQUIRED]`** blanks wherever a claim needs
+   human judgment. Voice: *careful, publishable, refuses to overclaim.* It reads the
+   Record plane only — never invents.
+
+**The crucial relationship to show:** Advisory *advises* the human; Record
+*witnesses* the human's actual choices; Narrative *publishes only what Record
+witnessed.* Advice that was never acted on does not reach the manuscript. Make this
+visible: an advisory finding that is dismissed should visibly *not* travel to the
+Record or Narrative lanes.
+
+---
+
+## 3. The modeling pipeline (the horizontal axis) — ten stages
+
+A left-to-right (on desktop) spine of nodes. As the reader scrolls, a **playhead**
+advances node by node; each node, when it becomes active, fires typed "packets"
+down into the lanes it writes to. Keep node copy terse; the lane pulses do the
+explaining.
+
+| # | Stage (page) | Data plane writes | Advisory | Record | Narrative |
+|---|---|---|---|---|---|
+| 1 | **Upload & Audit** (01) | `raw_data`; **lockbox drawn** — a 15% test slice sealed | audit warnings | `record_upload` | — |
+| 2 | **EDA** (02) | — (reads train rows only) | auto-insights (skew, missingness, correlations) | `record_eda_analysis` | — |
+| 3 | **Feature Engineering** (03) | `df_engineered` | — | `record_feature_engineering` | — |
+| 4 | **Feature Selection** (04) | `selected_features` | consensus notes | `record_feature_selection` | — |
+| 5 | **Preprocess + Coach** (05) | preprocessing pipelines | **coach shortlist + evidence-probe verdict** | `record_preprocessing`, `record_coach` | — |
+| 6 | **Train & Compare** (06) | `X_train/val/test` (from lockbox), `trained_models`, CV | post-training diagnostics (prefer-simpler, CI overlap, heteroscedasticity) | `record_split`, `record_training` | — |
+| 7 | **Explainability** (07) | importances, SHAP | (drift/robustness notes) | `record_explainability` | — |
+| 8 | **Sensitivity** (08) | seed / dropout robustness | — | `record_sensitivity` | — |
+| 9 | **Hypothesis Testing** (09) | group tests, effect sizes | — | `record_statistical_test` | — |
+| 10 | **Report Export** (10) | — | — | reads all slots | **`NarrativeEngine` compiles `ManuscriptDraft`** |
+
+By stage 10 the reader should *see* the Narrative lane assemble itself from the
+accumulated Record lane, blanks and all.
+
+---
+
+## 4. The three honesty disciplines (the emotional core — give each its own beat)
+
+These are the moments that make the piece more than a flowchart. Each deserves a
+dedicated scroll scene where the pipeline pauses and the mechanism animates.
+
+- **A. The lockbox (`utils/test_lockbox.py`).** At stage 1, a slice of the Data
+  lane (~15%) is drawn into a **sealed vault** and stays visibly sealed through
+  stages 2–5. Every target-aware step (EDA, FE fits, feature selection, the coach
+  probe) operates on `train_row_mask()` rows only — show these stages reaching
+  *around* the vault. The vault opens **exactly once**, at stage 6 (Train &
+  Compare), to score the final model. Tagline: *"The test set is sealed before
+  anyone looks at the data."*
+
+- **B. The invalidation cascade (`reset_downstream_results()`).** Show what happens
+  when the user changes something upstream (new data, a re-drawn lockbox, an applied
+  feature selection): a **"clear" wave** ripples downstream across *all four lanes*,
+  wiping stale results — pipelines, splits, models, insights, provenance sections.
+  Tagline: *"Absent is better than false."* (This is the principle the 2026-07
+  `CODE_REVIEW.md` section formalizes.) Ideal as a scroll-triggered "what if I
+  change my mind?" interlude.
+
+- **C. Provenance → manuscript.** At the end, draw the literal wires from Record
+  slots to manuscript sentences, and show an **`[AUTHOR REQUIRED]`** blank where the
+  chain has no evidence to draw on. Tagline: *"It writes what happened, and leaves a
+  labeled blank where only you can decide."*
+
+---
+
+## 5. Scroll narrative — scene-by-scene structure
+
+Design as a vertical sequence of full-height (or tall) scenes. Each scene: a
+**pinned/sticky visual** that animates as its text scrolls past, or a
+scroll-progress-driven reveal. Suggested sequence (you may merge/rename, but keep
+the arc):
+
+0. **Hero.** The one idea (§1) as a headline. A faint, still diagram of the spine +
+   four lanes previews the whole system. A scroll cue.
+1. **"Meet the four planes."** Introduce the lanes one at a time as the reader
+   scrolls — each lane draws in with its accent, name, one-line role, and its
+   source file as a small monospace tag. End with all four visible, empty, waiting.
+2. **Stage-by-stage build (the heart).** The playhead walks the pipeline. For each
+   stage: the node lights, a one-line description appears, and packets fly into the
+   lanes it writes to (per §3's table). The lanes visibly *accumulate*. Pace this so
+   ~2–3 stages share the viewport's scroll budget; don't make it 10 identical beats —
+   cluster (Ingest 1–2 · Shape 3–5 · Model 6 · Interrogate 7–9 · Publish 10).
+3. **Discipline A — the lockbox.** Pipeline pauses; the vault seals at stage 1 and
+   the reader scrolls the train-only stages reaching around it; the vault opens at
+   stage 6. (§4A)
+4. **Discipline B — the cascade.** A "you changed your mind" moment: a clear wave
+   sweeps all four lanes. (§4B)
+5. **Discipline C — the manuscript.** Record slots wire into manuscript sentences;
+   an `[AUTHOR REQUIRED]` blank glows where evidence is absent. (§4C)
+6. **The whole system, at rest.** All four lanes full, the spine complete, the
+   manuscript emitted. A closing line restating §1. Optional: a compact legend
+   mapping each lane to its file, so a curious viewer can go read the code.
+
+---
+
+## 6. Visual system (ground it in the app's own identity)
+
+The app already has an identity — **honor it, don't reinvent it.**
+
+- **Brand & palette.** Indigo is the app's signal color: `#667EEA` / `#7C8CF0`
+  (light indigo) → `#4034A8` (deep violet). Neutrals should be indigo-biased, not
+  pure grey. The app icon ("Distill") is a white Erlenmeyer flask holding a punched
+  data table on an indigo squircle — the piece's motif language is **lab + tabular
+  cells**, never finance/charts.
+- **Four lane accents.** Give each plane a distinct, harmonious hue that still
+  reads as one family. Suggestion (tune for contrast in both themes): Data =
+  indigo `#7C8CF0`; Advisory = amber/gold (it *advises*, warm); Record = teal/slate
+  (factual, cool); Narrative = a deeper violet/plum (the destination). Keep semantic
+  colors (a "clear/invalidate" red-orange, a "sealed" state) separate from the four
+  accents.
+- **Typography.** Pair a characterful display face for scene headlines with a clean
+  humanist sans for body, and a **monospace** for code symbols, file names, and
+  state-key labels (`df_engineered`, `record_split`, `[AUTHOR REQUIRED]`) — the
+  monospace tie-in to "this is real code" is doing real work. Inline faces as
+  `@font-face` data URIs (the Artifact CSP blocks font CDNs); if you can't, use a
+  strong system stack deliberately, not a silent fallback.
+- **Theme-aware.** Support light and dark via `prefers-color-scheme` **and** a
+  `data-theme` override; give both the same care. A dim conference room likely
+  means dark — make dark the confident default look.
+- **Motif consistency.** Data as small rounded **cells** (echoing the icon's table);
+  the lockbox as a sealed cell/vault; packets as small tokens moving along wires.
+  Keep it lab-instrument precise, not playful.
+
+---
+
+## 7. Motion & technical constraints
+
+- **Self-contained, single HTML file.** All CSS/JS inline; no external requests
+  (CSP blocks them). No animation libraries — hand-roll with `IntersectionObserver`
+  for enter triggers and a scroll-progress calc for scrubbed sequences. SVG or
+  Canvas for the spine/lanes/packets; prefer Canvas for many moving tokens.
+- **Scroll-driven, not autoplay.** Progress is tied to scroll position; scrolling
+  up reverses/re-arms. Nothing important animates while off-screen.
+- **Animate only `transform` and `opacity`** for 60fps; avoid layout-thrashing
+  properties. Throttle scroll work with `requestAnimationFrame`.
+- **`prefers-reduced-motion`:** provide a graceful static/step-through version —
+  every scene must still communicate with motion disabled (packets appear in place;
+  the vault shows a sealed vs. open state without the travel).
+- **Responsive.** On narrow screens the four lanes may stack or the spine may become
+  vertical; content must never require horizontal page scroll. Wide diagrams live in
+  their own `overflow-x:auto` container.
+- **Accessibility.** Real headings, sufficient contrast in both themes, visible
+  focus states, `aria` labels on the diagram; the piece should be readable as a
+  document even if JS fails.
+- **Performance budget.** Target a light file; lazy-init heavy Canvas scenes when
+  near viewport.
+
+---
+
+## 8. Accuracy guardrails (the part that makes it trustworthy)
+
+- **Do not invent stages, planes, methods, or numbers.** Ten stages, four planes.
+  If you show an example metric, mark it clearly as illustrative — or pull the real
+  seed-42 NHANES figures only if the user provides them; otherwise keep numbers
+  schematic.
+- **Every code label must be real.** `df_engineered`, `train_row_mask`,
+  `record_training`, `InsightLedger.prune_auto_generated`, `[AUTHOR REQUIRED]` — all
+  exist; open the files to copy exact names.
+- **The honesty theme is the soul, not decoration.** The lockbox, the cascade, and
+  provenance→manuscript are why this app exists. If a design trade-off threatens one
+  of those three beats, protect the beat.
+- **The four planes advise/witness/publish in that order of authority.** Never draw
+  the Advisory plane writing directly into the Narrative plane — advice reaches the
+  manuscript only by being acted on and thereby recorded.
+
+---
+
+## 9. Acceptance checklist
+
+- [ ] A first-time viewer can name the four planes and say what each does.
+- [ ] The ten-stage pipeline is correct and in order; each stage's lane-writes match §3.
+- [ ] The lockbox seals at stage 1, is respected through 2–5, opens once at stage 6.
+- [ ] The invalidation cascade visibly clears **all four** lanes.
+- [ ] The manuscript assembles from Record slots and shows at least one `[AUTHOR REQUIRED]` blank.
+- [ ] Every code/state label on screen exists in the repo.
+- [ ] Works scrolled up and down; degrades cleanly under `prefers-reduced-motion`; no horizontal page scroll; light + dark both polished.
+- [ ] Single self-contained HTML, no external requests, 60fps on a laptop.
+
+---
+
+*Authored from the live architecture of Tabular ML Lab. The downstream design
+session has repo access — when in doubt, open the file and read it.*

--- a/ml/calibration.py
+++ b/ml/calibration.py
@@ -117,8 +117,22 @@ def calibration_regression(
     from sklearn.linear_model import LinearRegression
     from sklearn.metrics import r2_score
 
-    y_true = np.asarray(y_true).ravel()
-    y_pred = np.asarray(y_pred).ravel()
+    y_true = np.asarray(y_true, dtype=float).ravel()
+    y_pred = np.asarray(y_pred, dtype=float).ravel()
+
+    # A diverged model (e.g. a neural net) can emit NaN/inf predictions;
+    # LinearRegression rejects them with a page-crashing ValueError. Fit the
+    # calibration line on the finite pairs only, and raise a clear error when
+    # there is nothing usable — callers surface it as a per-model note.
+    finite = np.isfinite(y_true) & np.isfinite(y_pred)
+    if int(finite.sum()) < 2:
+        raise ValueError(
+            f"{model_name}: fewer than 2 finite prediction pairs "
+            f"({int((~finite).sum())} non-finite of {len(y_pred)}) — "
+            "the model's predictions are unusable for calibration."
+        )
+    y_true = y_true[finite]
+    y_pred = y_pred[finite]
 
     reg = LinearRegression()
     reg.fit(y_pred.reshape(-1, 1), y_true)

--- a/pages/01_Upload_and_Audit.py
+++ b/pages/01_Upload_and_Audit.py
@@ -1646,6 +1646,27 @@ if task_mode == "prediction":
                 "step can peek at it. Changing it (or toggling exploratory "
                 "mode in either direction) resets downstream results."
             )
+            # Session restore defers widget keys via _pending_widget_state_restore;
+            # each widget's owner claims its key before instantiation. This page
+            # owns exploratory_mode — without this, a restored exploratory flag
+            # would sit in the pending dict forever and silently never apply.
+            _pending_restore = st.session_state.get("_pending_widget_state_restore", {})
+            if "exploratory_mode" in _pending_restore:
+                st.session_state["exploratory_mode"] = bool(
+                    _pending_restore.pop("exploratory_mode")
+                )
+                if _pending_restore:
+                    st.session_state["_pending_widget_state_restore"] = _pending_restore
+                else:
+                    st.session_state.pop("_pending_widget_state_restore", None)
+                if st.session_state["exploratory_mode"]:
+                    # Restored sessions in exploratory mode keep their honesty
+                    # watermark; quarantine-off must never arrive silently.
+                    st.session_state["exploratory_used"] = True
+                    st.warning(
+                        "🔓 This restored session was saved in **exploratory mode** — "
+                        "the test-set quarantine is OFF, as it was when saved."
+                    )
             _lb_frac = st.slider(
                 "Held-out test fraction", 0.05, 0.40,
                 float(st.session_state.get("test_lockbox_fraction", DEFAULT_TEST_FRACTION)),

--- a/pages/06_Train_and_Compare.py
+++ b/pages/06_Train_and_Compare.py
@@ -1988,6 +1988,29 @@ if st.session_state.get('trained_models'):
                 y_test_local = np.array(results["y_test"])
                 y_pred_local = np.array(results["y_test_pred"])
 
+                # A model whose stored predictions contain NaN/inf (diverged
+                # NN, degenerate target-transform back-mapping) must not crash
+                # the whole CI run — resample the finite pairs and say so.
+                _finite_local = np.isfinite(
+                    np.asarray(y_test_local, dtype=float)
+                ) & np.isfinite(np.asarray(y_pred_local, dtype=float))
+                if not _finite_local.all():
+                    _n_dropped = int((~_finite_local).sum())
+                    if int(_finite_local.sum()) < 10:
+                        st.warning(
+                            f"⚠️ {name.upper()}: too few finite predictions for "
+                            f"bootstrap CIs ({_n_dropped} non-finite) — skipped. "
+                            f"Inspect this model's training."
+                        )
+                        progress.progress((i + 1) / len(model_names_list))
+                        continue
+                    st.caption(
+                        f"⚠️ {name.upper()}: {_n_dropped} non-finite prediction(s) "
+                        f"excluded from bootstrap CIs."
+                    )
+                    y_test_local = y_test_local[_finite_local]
+                    y_pred_local = y_pred_local[_finite_local]
+
                 if data_config.task_type == "regression":
                     cis = bootstrap_all_regression_metrics(y_test_local, y_pred_local, n_resamples=1000)
                 else:
@@ -2003,6 +2026,13 @@ if st.session_state.get('trained_models'):
                                     y_proba_local = y_proba_local[:, 1]
                             except Exception:
                                 pass
+                    # Keep probabilities aligned with the finite-filtered labels.
+                    if (
+                        y_proba_local is not None
+                        and not _finite_local.all()
+                        and len(y_proba_local) == len(_finite_local)
+                    ):
+                        y_proba_local = np.asarray(y_proba_local)[_finite_local]
                     cis = bootstrap_all_classification_metrics(y_test_local, y_pred_local, y_proba=y_proba_local, n_resamples=1000)
 
                 bootstrap_results[name] = cis
@@ -2132,15 +2162,27 @@ if st.session_state.get('trained_models'):
                             st.caption(f"Could not compute calibration for {name}: {e}")
         else:
             for name, results in st.session_state.model_results.items():
-                from ml.calibration import calibration_regression
-                cal = calibration_regression(
-                    np.array(results["y_test"]), np.array(results["y_test_pred"]),
-                    model_name=name.upper(),
-                )
-                _calibration_by_model[name] = cal
-                st.markdown(f"**{name.upper()}:** Calibration slope = {cal.calibration_slope:.3f}, "
-                           f"Intercept = {cal.calibration_intercept:.3f} "
-                           f"(perfect: slope=1, intercept=0)")
+                # One model's bad predictions (a diverged NN emits NaN) must
+                # not crash the whole results section — mirror the per-model
+                # try/except the classification branch above already has.
+                try:
+                    from ml.calibration import calibration_regression
+                    _yt = np.asarray(results["y_test"], dtype=float)
+                    _yp = np.asarray(results["y_test_pred"], dtype=float)
+                    _n_bad = int((~(np.isfinite(_yt) & np.isfinite(_yp))).sum())
+                    cal = calibration_regression(_yt, _yp, model_name=name.upper())
+                    _calibration_by_model[name] = cal
+                    st.markdown(f"**{name.upper()}:** Calibration slope = {cal.calibration_slope:.3f}, "
+                               f"Intercept = {cal.calibration_intercept:.3f} "
+                               f"(perfect: slope=1, intercept=0)")
+                    if _n_bad:
+                        st.caption(
+                            f"⚠️ {name.upper()}: {_n_bad} non-finite prediction(s) "
+                            f"excluded from calibration — inspect this model's "
+                            f"training (it may have diverged)."
+                        )
+                except Exception as e:
+                    st.warning(f"⚠️ Could not compute calibration for {name.upper()}: {e}")
             st.caption("Calibration slope measures systematic over/under-prediction. "
                       "Slope < 1 = predictions too extreme; slope > 1 = predictions too conservative.")
         # Persist for Report Export — previously computed here but never stored,

--- a/tests/test_review_fixes.py
+++ b/tests/test_review_fixes.py
@@ -588,3 +588,29 @@ class TestLayerContracts:
                              metrics_by_model={"ridge": {"R2": 0.6}})
         draft2 = NarrativeEngine(prov).generate()
         assert "shortlisted from the dataset" in draft2.model_development
+
+
+# ── Calibration must survive non-finite predictions ──────────────────────
+
+class TestCalibrationNaNSafety:
+    """A diverged model (NN, degenerate target-transform back-mapping) stores
+    NaN predictions; metrics already drop them, so the NaNs reach the results
+    section. calibration_regression previously crashed the whole page render
+    with sklearn's 'Input X contains NaN'."""
+
+    def test_calibration_fits_on_finite_subset(self):
+        from ml.calibration import calibration_regression
+        rng = np.random.RandomState(0)
+        y_true = rng.rand(50) * 10
+        y_pred = y_true + rng.rand(50)
+        y_pred[::7] = np.nan          # a diverged model's bad rows
+        cal = calibration_regression(y_true, y_pred, model_name="TEST")
+        assert np.isfinite(cal.calibration_slope)
+        assert np.isfinite(cal.calibration_intercept)
+
+    def test_calibration_raises_clear_error_when_all_nan(self):
+        from ml.calibration import calibration_regression
+        y_true = np.arange(20.0)
+        y_pred = np.full(20, np.nan)
+        with pytest.raises(ValueError, match="finite prediction pairs"):
+            calibration_regression(y_true, y_pred, model_name="TEST")

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -93,6 +93,31 @@ def _populated_state(state):
     ))
     state["insight_ledger"] = ledger
 
+    # Schema 2.1 recipe state: the sealed holdout (numpy labels, as the real
+    # lockbox stores them), its fraction, and the keys a restore previously lost.
+    state["test_lockbox"] = {
+        "labels": [np.int64(1), np.int64(3)],
+        "fraction": 0.25,
+        "seed": 42,
+        "n_total": 4,
+        "n_test": 2,
+        "signature": "sig-abc",
+        "stratified": False,
+    }
+    state["test_lockbox_fraction"] = 0.25
+    state["pre_fe_feature_cols"] = ["age", "bmi"]
+    state["preprocess_built_model_keys"] = ["ridge", "huber"]
+    state["engineered_feature_transforms"] = {"age_sq": "square"}
+    state["exploratory_mode"] = True  # widget key; travels via widget_state.json
+
+    from ml.coach_probe import ProbeResult
+    state["coach_probe_result"] = ProbeResult(
+        task_type="regression", n_rows_used=4, n_features_used=2,
+        subsampled=False, linear_score=0.12, permuted_score=-0.01,
+        permuted_spread=0.02, tree_score=0.10, half_data_score=0.08,
+        metric_name="R²", notes=["ok"],
+    )
+
     # Things that must NEVER be written to the save file.
     state["trained_models"] = {"rf": object()}
     state["fitted_estimators"] = {"rf": object()}
@@ -113,7 +138,7 @@ def test_save_produces_valid_zip(fake_session):
     _populated_state(fake_session)
     archive_bytes, manifest = _collect_session_data()
     assert zipfile.is_zipfile(io.BytesIO(archive_bytes))
-    assert manifest["schema_version"] == "2.0"
+    assert manifest["schema_version"] == "2.1"
     assert "data_config" in manifest["saved_keys"]
     assert "insight_ledger" in manifest["saved_keys"]
 
@@ -169,7 +194,8 @@ def test_round_trip_preserves_values(fake_session):
 
     # Simulate a fresh session by clearing + restoring.
     fake_session.clear()
-    restored_count, manifest = _restore_session_data(archive_bytes)
+    restored_count, manifest, load_warnings = _restore_session_data(archive_bytes)
+    assert load_warnings == []
     assert restored_count > 0
     assert manifest["workflow_step"] == "05_Preprocess"
 
@@ -349,3 +375,84 @@ def test_unknown_config_keys_are_ignored_not_restored(fake_session):
     # trained_models is in NEVER_PERSIST so it was cleared by
     # _clear_downstream_state; we assert it was not overwritten from the file.
     assert fake_session.get("trained_models") != {"rf": "attacker_payload"}
+
+
+# --- Schema 2.1: the recipe state a restore previously lost ----------------
+
+def _save_clear_restore(fake_session):
+    from utils.session_manager import _collect_session_data, _restore_session_data
+    _populated_state(fake_session)
+    archive_bytes, _ = _collect_session_data()
+    fake_session.clear()
+    return _restore_session_data(archive_bytes)
+
+
+def test_round_trip_restores_lockbox_with_int_labels(fake_session):
+    """The sealed holdout must survive VERBATIM. numpy int labels must come
+    back as python ints — stringified labels would silently fail membership
+    against the dataframe's integer index (an all-False test mask)."""
+    _save_clear_restore(fake_session)
+    lb = fake_session["test_lockbox"]
+    assert lb["labels"] == [1, 3]
+    assert all(type(x) is int for x in lb["labels"])
+    assert lb["fraction"] == 0.25
+    assert lb["seed"] == 42
+    assert lb["n_test"] == 2
+    # The fraction key is kept coherent with the restored lockbox so a
+    # redraw (if the data signature shifts) uses the SAME holdout percent.
+    assert fake_session["test_lockbox_fraction"] == 0.25
+
+
+def test_round_trip_restores_recipe_keys(fake_session):
+    _save_clear_restore(fake_session)
+    assert fake_session["pre_fe_feature_cols"] == ["age", "bmi"]
+    assert fake_session["preprocess_built_model_keys"] == ["ridge", "huber"]
+    assert fake_session["engineered_feature_transforms"] == {"age_sq": "square"}
+
+
+def test_round_trip_restores_coach_probe(fake_session):
+    from ml.coach_probe import ProbeResult
+    _save_clear_restore(fake_session)
+    probe = fake_session["coach_probe_result"]
+    assert isinstance(probe, ProbeResult)
+    assert probe.linear_score == 0.12
+    assert probe.metric_name == "R²"
+    assert probe.notes == ["ok"]
+
+
+def test_exploratory_mode_travels_via_widget_state(fake_session):
+    """exploratory_mode is a widget key (page 01 checkbox): it must restore
+    via the deferred widget mechanism, never by direct assignment."""
+    _save_clear_restore(fake_session)
+    assert "exploratory_mode" not in fake_session or fake_session.get(
+        "exploratory_mode") is not True  # not directly assigned
+    pending = fake_session.get("_pending_widget_state_restore", {})
+    assert pending.get("exploratory_mode") is True
+
+
+def test_legacy_2_0_archive_still_loads(fake_session):
+    """A 2.0 file (no lockbox.json / coach_probe.json) must load cleanly —
+    users' existing saves keep working after the schema bump."""
+    from utils.session_manager import _restore_session_data
+
+    members = {
+        "manifest.json": json.dumps({
+            "schema_version": "2.0",
+            "saved_at": "2026-06-01T00:00:00",
+            "workflow_step": "02_EDA",
+            "saved_keys": ["random_seed"], "skipped_keys": [], "members": [],
+        }).encode(),
+        "config.json": json.dumps({"random_seed": 7}).encode(),
+        "widget_state.json": b"{}",
+    }
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for name, data in members.items():
+            zf.writestr(name, data)
+
+    restored_count, manifest, load_warnings = _restore_session_data(buf.getvalue())
+    assert restored_count >= 1
+    assert load_warnings == []
+    assert fake_session["random_seed"] == 7
+    # No lockbox member -> no lockbox key invented
+    assert "test_lockbox" not in fake_session

--- a/utils/session_manager.py
+++ b/utils/session_manager.py
@@ -25,6 +25,10 @@ Members:
     widget_state.json          -- safe widget keys (NO API keys)
     coaching.json              -- InsightLedger.to_list()
     provenance.json            -- WorkflowProvenance.to_dict() (if present)
+    lockbox.json               -- the sealed test-set labels + fraction/seed
+                                  (schema >= 2.1; restoring the exact holdout
+                                  keeps results comparable across sessions)
+    coach_probe.json           -- ProbeResult numbers (schema >= 2.1)
     data/<name>.parquet        -- DataFrames, one per entry
     datasets/<id>.parquet      -- entries from datasets_registry
     datasets/index.json        -- name mapping for datasets_registry
@@ -50,7 +54,10 @@ import pandas as pd
 import streamlit as st
 
 
-SAVE_SCHEMA_VERSION = "2.0"
+SAVE_SCHEMA_VERSION = "2.1"
+# Older schemas this app still loads. 2.0 files simply lack the newer members
+# (lockbox.json, coach_probe.json); everything present is restored as before.
+_ACCEPTED_SCHEMA_VERSIONS = {"2.0", "2.1"}
 SAVE_EXTENSION = "tmllab"
 
 # Upper bounds on input size -- zip-bomb defense-in-depth beyond Streamlit's
@@ -102,6 +109,11 @@ _PLAIN_KEYS: Tuple[str, ...] = (
     "workflow_mode",
     "methodology_log",
     "current_page",
+    # -- schema 2.1 additions: recipe state a restore previously lost --
+    "test_lockbox_fraction",       # non-default holdout % must survive restore
+    "pre_fe_feature_cols",         # lets FE Reset/Skip restore the original list
+    "preprocess_built_model_keys", # which models had pipelines configured
+    "engineered_feature_transforms",  # double-transform guard's map
 )
 
 # Deferred widget keys -- stored separately because Streamlit requires setting
@@ -114,6 +126,9 @@ _SAFE_WIDGET_KEYS: Set[str] = {
     "openai_model",
     "anthropic_model",
     "workflow_mode_selector",
+    # Widget-keyed checkbox on Upload & Audit; restored via the deferred
+    # mechanism so we never assign an already-instantiated widget's key.
+    "exploratory_mode",
 }
 
 _PENDING_WIDGET_RESTORE_KEY = "_pending_widget_state_restore"
@@ -260,6 +275,51 @@ def _build_archive_members() -> Dict[str, bytes]:
         except Exception:
             skipped_keys.append("workflow_provenance")
 
+    # --- Test-set lockbox (schema 2.1) ---
+    # The sealed holdout must survive a save/restore VERBATIM: re-drawing it
+    # with a lost non-default fraction would silently change the test set that
+    # every prior result was scored on. Labels are coerced to plain int/str
+    # here because json.dumps(default=str) would turn numpy ints into strings,
+    # and string labels would no longer match the dataframe's integer index on
+    # restore (a silent all-False membership).
+    lockbox = st.session_state.get("test_lockbox")
+    if isinstance(lockbox, dict) and lockbox.get("labels") is not None:
+        try:
+            def _plain_label(x: Any) -> Any:
+                if isinstance(x, bool):
+                    return str(x)
+                if isinstance(x, int):
+                    return x
+                if hasattr(x, "item"):          # numpy scalar -> python scalar
+                    v = x.item()
+                    return v if isinstance(v, int) else str(v)
+                return str(x)
+
+            encoded = {
+                "labels": [_plain_label(lbl) for lbl in lockbox["labels"]],
+                "fraction": float(lockbox.get("fraction", 0.15)),
+                "seed": int(lockbox.get("seed", 42)),
+                "n_total": int(lockbox.get("n_total", 0)),
+                "n_test": int(lockbox.get("n_test", len(lockbox["labels"]))),
+                "signature": str(lockbox.get("signature", "")),
+                "stratified": bool(lockbox.get("stratified", False)),
+            }
+            members["lockbox.json"] = json.dumps(encoded, indent=2).encode("utf-8")
+            saved_keys.append("test_lockbox")
+        except Exception:
+            skipped_keys.append("test_lockbox")
+
+    # --- Coach evidence probe (schema 2.1) ---
+    probe = st.session_state.get("coach_probe_result")
+    if probe is not None and is_dataclass(probe):
+        try:
+            members["coach_probe.json"] = json.dumps(
+                _json_safe(asdict(probe)), indent=2
+            ).encode("utf-8")
+            saved_keys.append("coach_probe_result")
+        except Exception:
+            skipped_keys.append("coach_probe_result")
+
     # --- Manifest (written last so it can reference what landed) ---
     manifest = {
         "schema_version": SAVE_SCHEMA_VERSION,
@@ -372,10 +432,13 @@ def _clear_downstream_state() -> None:
     st.session_state.pop("_working_table_source_id", None)
 
 
-def _restore_session_data(archive_bytes: bytes) -> Tuple[int, Dict[str, Any]]:
+def _restore_session_data(archive_bytes: bytes) -> Tuple[int, Dict[str, Any], list]:
     """Parse archive, validate, apply to st.session_state.
 
-    Returns (restored_count, manifest).
+    Returns (restored_count, manifest, warnings) — warnings is a list of
+    human-readable strings for members that were present but could not be
+    restored (surfaced in the sidebar; a partial restore must never be
+    silent).
     Raises SessionLoadError on any validation failure.
     """
     if len(archive_bytes) > _MAX_UPLOAD_BYTES:
@@ -406,15 +469,17 @@ def _restore_session_data(archive_bytes: bytes) -> Tuple[int, Dict[str, Any]]:
             raise SessionLoadError("Archive is missing manifest.json.")
         manifest = _read_json(zf, "manifest.json")
         version = str(manifest.get("schema_version", ""))
-        if version != SAVE_SCHEMA_VERSION:
+        if version not in _ACCEPTED_SCHEMA_VERSIONS:
             raise SessionLoadError(
                 f"Unsupported session schema version {version!r} "
-                f"(this app writes {SAVE_SCHEMA_VERSION!r})."
+                f"(this app writes {SAVE_SCHEMA_VERSION!r} and accepts "
+                f"{sorted(_ACCEPTED_SCHEMA_VERSIONS)})."
             )
 
         # Clear derived/trained state up front.
         _clear_downstream_state()
         restored = 0
+        warnings: list = []
 
         # --- DataFrames ---
         for key in _DATAFRAME_KEYS:
@@ -485,9 +550,57 @@ def _restore_session_data(archive_bytes: bytes) -> Tuple[int, Dict[str, Any]]:
                     st.session_state["workflow_provenance"] = WorkflowProvenance.from_dict(data)
                     restored += 1
                 except Exception:
-                    pass
+                    warnings.append(
+                        "Workflow record could not be restored — the manuscript "
+                        "compiler will start from what you re-run."
+                    )
 
-    return restored, manifest
+        # --- Test-set lockbox (schema 2.1; absent in 2.0 files) ---
+        if "lockbox.json" in names:
+            try:
+                data = _read_json(zf, "lockbox.json")
+                labels = data.get("labels")
+                if not isinstance(labels, list) or not labels:
+                    raise ValueError("lockbox has no labels")
+                st.session_state["test_lockbox"] = {
+                    "labels": list(labels),
+                    "fraction": float(data.get("fraction", 0.15)),
+                    "seed": int(data.get("seed", 42)),
+                    "n_total": int(data.get("n_total", 0)),
+                    "n_test": int(data.get("n_test", len(labels))),
+                    "signature": str(data.get("signature", "")),
+                    "stratified": bool(data.get("stratified", False)),
+                }
+                # Keep the fraction key coherent with the restored lockbox even
+                # if config.json predates it or disagrees.
+                st.session_state["test_lockbox_fraction"] = float(
+                    data.get("fraction", 0.15)
+                )
+                restored += 1
+            except Exception as exc:
+                warnings.append(
+                    f"Sealed test set could not be restored ({exc}) — it will "
+                    "be re-drawn from the saved seed and fraction on Upload & "
+                    "Audit."
+                )
+
+        # --- Coach evidence probe (schema 2.1) ---
+        if "coach_probe.json" in names:
+            try:
+                data = _read_json(zf, "coach_probe.json")
+                from ml.coach_probe import ProbeResult
+                valid = set(ProbeResult.__dataclass_fields__.keys())
+                st.session_state["coach_probe_result"] = ProbeResult(
+                    **{k: v for k, v in data.items() if k in valid}
+                )
+                restored += 1
+            except Exception:
+                warnings.append(
+                    "Coach probe evidence could not be restored — re-run the "
+                    "evidence probe on Preprocess (~10 s)."
+                )
+
+    return restored, manifest, warnings
 
 
 # ---------------------------------------------------------------------------
@@ -553,16 +666,33 @@ def render_session_controls() -> None:
         saved_date = saved_at[:10] if saved_at != "Unknown" else "Unknown"
         workflow_step = restore_notice.get("workflow_step", "Unknown")
         restored_count = restore_notice.get("restored_count", 0)
-        st.sidebar.success(f"""
-        ✅ **Session Restored!**
 
-        - **Saved:** {saved_date}
-        - **Items restored:** {restored_count}
-        - **Last step:** {workflow_step}
-
-        Trained models are cleared on restore -- re-run the Train page
-        to regenerate them from the restored configuration.
-        """)
+        # Resume checklist: say exactly what came back and which clicks
+        # regenerate the rest. Results are re-computed, never deserialized —
+        # that is the format's safety contract.
+        lb = st.session_state.get("test_lockbox") or {}
+        lockbox_line = (
+            f"- 🔒 **Test set restored:** the same {lb.get('fraction', 0):.0%} "
+            f"holdout (n={lb.get('n_test', 0)}) — results stay comparable\n"
+            if lb.get("labels") else
+            "- 🔒 Test set will be re-drawn from the saved seed on Upload & Audit\n"
+        )
+        built = st.session_state.get("preprocess_built_model_keys") or []
+        built_line = (
+            f"- ⚙️ Pipeline configs ready for: **{', '.join(map(str, built))}**\n"
+            if built else ""
+        )
+        st.sidebar.success(
+            f"✅ **Session Restored** (saved {saved_date}, "
+            f"{restored_count} items, last step: {workflow_step})\n\n"
+            f"{lockbox_line}"
+            f"{built_line}"
+            f"\n**To regenerate results (recomputed, not deserialized):**\n"
+            f"1. **Preprocess** → Build Pipelines (settings pre-filled)\n"
+            f"2. **Train & Compare** → Prepare Splits → Train Models\n"
+        )
+        for w in restore_notice.get("warnings", []):
+            st.sidebar.warning(f"⚠️ {w}")
 
     # --- Save ---
     if st.sidebar.button("📥 Save Progress", help="Download your current workflow state"):
@@ -614,12 +744,13 @@ def render_session_controls() -> None:
     if uploaded_session is not None:
         try:
             archive_bytes = uploaded_session.read()
-            restored_count, manifest = _restore_session_data(archive_bytes)
+            restored_count, manifest, load_warnings = _restore_session_data(archive_bytes)
             st.session_state["upload_session_file_nonce"] = uploader_nonce + 1
             st.session_state["session_restore_notice"] = {
                 "saved_at": manifest.get("saved_at", "Unknown"),
                 "restored_count": restored_count,
                 "workflow_step": manifest.get("workflow_step", "Unknown"),
+                "warnings": load_warnings,
             }
             st.rerun()
         except SessionLoadError as exc:


### PR DESCRIPTION
Pre-demo wave: keep `.tmllab` pickle-free while making restore trustworthy, and fix a page-crashing NaN path found on a real run.

## Session restore keeps the sealed test set and the full recipe (`06d57f6`)
The `.tmllab` format stays JSON+Parquet-in-a-ZIP — results are recomputed, never deserialized. This closes the fidelity gaps that made that trade-off feel costly:

- **Lockbox persisted verbatim** (labels, fraction, seed, signature). Previously a restore re-drew it and a non-default holdout fraction was lost — silently changing the test set every prior result was scored on. Labels are coerced to plain int/str on save (json `default=str` would stringify numpy ints and silently break index membership on load).
- **Recipe keys now round-trip:** `test_lockbox_fraction`, `pre_fe_feature_cols` (FE Reset/Skip semantics), `preprocess_built_model_keys`, `engineered_feature_transforms`, and the coach evidence probe.
- **`exploratory_mode`** travels via the deferred widget mechanism; page 01 now owns applying it (it previously had no owner and would sit pending forever), and a restored quarantine-off session announces itself loudly.
- **Schema 2.1; 2.0 files still load.** Partial restores surface per-member warnings, and the restore notice is now a resume checklist (what came back + which two clicks regenerate the rest).

## NaN-safe calibration and bootstrap CIs (`f3ea7b7`)
Reported from a real run: visiting Train & Compare after a model stored NaN predictions crashed the whole page render (`Input X contains NaN` from `LinearRegression` inside `calibration_regression`). Metrics already drop non-finite pairs by design, so NaNs from a diverged model or degenerate target-transform back-mapping legitimately reach `model_results` — every render-time sklearn fit must tolerate them:

- `calibration_regression` fits on finite pairs only; clear per-model error when <2 remain.
- The regression calibration loop gets the per-model try/except the classification branch already had, plus a visible "N non-finite excluded" note.
- The bootstrap-CI loop filters non-finite pairs per model (skips with a warning under 10 usable) and keeps classification probabilities aligned with the filtered labels.

## Also included (`7a2ad8b`)
`docs/ARCHITECTURE_SCROLLYTELLING_BRIEF.md` — hand-off design brief for the scroll-animated architecture explainer.

## Verification
- Full suite **612 passed, 4 skipped** (deterministic run); session-manager suite 20/20 including int-label lockbox round-trip and legacy-2.0 compatibility; page-06 AppTests green.
- App boots to HTTP 200 in ~1 s.
- **No dependency changes** — the one-click download path is untouched and existing installs won't rebuild their venv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Y6pZssF946f2jqcuoYKkz

---
_Generated by [Claude Code](https://claude.ai/code/session_016Y6pZssF946f2jqcuoYKkz)_