### PR TITLE
Leave Upload &amp; Audit knowing what your working table is

### DIFF
--- a/pages/01_Upload_and_Audit.py
+++ b/pages/01_Upload_and_Audit.py
@@ -43,6 +43,23 @@ from ml.eda_recommender import compute_dataset_signals
 logger = logging.getLogger(__name__)
 
 
+def _forget_working_table(reason: str = "") -> None:
+    """Drop the working table AND the account of how it was built.
+
+    These have to move together. Three buttons used to drop the table and
+    leave the ledger standing — "Change Merge Setup" most damagingly, because
+    the next combine appended a second "Combined 3 files" step to an account
+    that still described the first, giving a lineage whose before/after chain
+    did not join up.
+    """
+    for key in ("working_table", "_combine_signature", "_combine_reopen",
+                "_working_table_source_id", "merge_preview", "merge_config"):
+        st.session_state.pop(key, None)
+    _ledger.clear()
+    if reason:
+        st.session_state["_working_table_forgotten"] = reason
+
+
 def _origin_notes(dataset_ids) -> list:
     """What was done to each file BEFORE it became part of the working table.
 
@@ -140,9 +157,7 @@ with st.sidebar:
             st.rerun()
         
         if st.button("Change Merge Setup", type="secondary", key="change_merge", help="Go back to re-merge your datasets"):
-            st.session_state.pop('working_table', None)
-            st.session_state.pop('merge_preview', None)
-            st.session_state.pop('merge_config', None)
+            _forget_working_table("You asked to change how the files are combined.")
             st.session_state.pop('merge_steps', None)
             st.session_state.pop('last_merge_columns', None)
             st.session_state.pop('transposed_for_merge', None)
@@ -168,7 +183,8 @@ with st.sidebar:
             with c1:
                 if st.button("Yes, Clear Session", type="primary", key="confirm_clear_yes"):
                     st.session_state.pop('datasets_registry', None)
-                    st.session_state.pop('working_table', None)
+                    st.session_state.pop('_dataset_origin', None)
+                    _forget_working_table()
                     st.session_state.pop('merge_steps', None)
                     st.session_state.pop('transposed_for_merge', None)
                     st.session_state.pop('confirm_clear_session', None)
@@ -195,6 +211,13 @@ if not active_project:
 # ============================================================================
 st.markdown("---")
 st.header("Step 1: Add Your Data")
+
+# Anything that discarded the working table says so here, once, where the
+# researcher is looking — rather than leaving them to notice that Step 2 has
+# quietly reverted to asking how to combine their files.
+_forgotten = st.session_state.pop("_working_table_forgotten", None)
+if _forgotten:
+    st.warning(f"↩️ {_forgotten}")
 st.caption(
     "Bring one file or bring all of them. If your study lives in several files "
     "that you have never combined — demographics here, labs there, diet in a "
@@ -236,13 +259,27 @@ if project_datasets:
                     db.rename_dataset(d['id'], new_name)
                     st.rerun()
         with c3:
-            if st.button("Remove", key=f"del_{d['id']}", type="secondary"):
+            # Removing a file rebuilds the study from a different set of files,
+            # so the working table and everything measured from it stop being
+            # about the same data. That is the right behavior, but it used to
+            # happen on one unlabeled click; say it on the button.
+            _costs_table = st.session_state.get("working_table") is not None
+            if st.button(
+                "Remove", key=f"del_{d['id']}", type="secondary",
+                help=(f"Take {d['name']} out of the study. Your combined table "
+                      f"is discarded and you will combine the remaining files "
+                      f"again." if _costs_table else
+                      f"Take {d['name']} out of the study."),
+            ):
                 db.delete_dataset(d['id'])
                 st.session_state.datasets_registry.pop(d['id'], None)
+                (st.session_state.get("_dataset_origin") or {}).pop(d['id'], None)
                 # The working table was built from a set of files that no
                 # longer exists; forcing a recombine is the only honest move.
-                st.session_state.pop("working_table", None)
-                st.session_state.pop("_combine_signature", None)
+                _forget_working_table(
+                    f"**{d['name']}** was removed from the study, so the combined "
+                    f"table built from it was discarded. Combine the remaining "
+                    f"files again below.")
                 st.rerun()
     st.markdown("---")
 
@@ -348,9 +385,9 @@ def _commit_dataset(df, dataset_name, filename, file_type, transposed,
         "filename": filename,
     }
     # A new file changes what "combined" means, so any table built from the
-    # previous set of files must not survive as the working table.
-    st.session_state.pop("working_table", None)
-    st.session_state.pop("_combine_signature", None)
+    # previous set of files must not survive as the working table — nor the
+    # account of how that table was built.
+    _forget_working_table()
     return True, dataset_name
 
 
@@ -626,9 +663,10 @@ if len(project_datasets) > 1:
     # combination while the page reports "ready".
     _combo_signature = "|".join(sorted(dataframes)) + f"|{len(dataframes)}"
     if st.session_state.get("_combine_signature") != _combo_signature:
-        st.session_state.pop("working_table", None)
+        # A different set of files is a different table, and a different
+        # account of how it was built.
+        _forget_working_table()
         st.session_state["_combine_signature"] = _combo_signature
-        _ledger.clear()          # a different set of files is a different table
 
     # Once a table has been committed, the combine step is HISTORY, not a
     # control. Re-rendering the full preview on every rerun left its headline

--- a/pages/01_Upload_and_Audit.py
+++ b/pages/01_Upload_and_Audit.py
@@ -27,7 +27,9 @@ from utils.session_projects import get_project_manager
 from utils.column_utils import make_unique_columns
 from utils.theme import inject_custom_css, render_guidance, render_sidebar_workflow
 from utils.table_export import table
-from utils.import_ui import render_import_doctor, repaired_frame
+from utils.import_ui import render_import_doctor, repaired_frame, applied_fixes
+from utils import table_ledger as _ledger
+from utils.working_table_ui import render_working_table_card, render_exit_assurance
 from data_processor import (
     load_tabular_data, get_numeric_columns, get_selectable_columns,
     detect_file_type, inspect_json
@@ -39,6 +41,22 @@ from ml.triage import detect_task_type, detect_cohort_structure
 from ml.eda_recommender import compute_dataset_signals
 
 logger = logging.getLogger(__name__)
+
+
+def _applied_fix_notes(dataset) -> list:
+    """Import Doctor repairs applied to the file this table came from.
+
+    They happen per-file, before the working table exists, so they are carried
+    onto the step that adopts the file rather than lost between the two.
+    """
+    notes = []
+    try:
+        for _key in (dataset.get('id'), dataset.get('filename'), dataset.get('name')):
+            if _key:
+                notes.extend(applied_fixes(str(_key)))
+    except Exception:
+        pass
+    return notes
 
 
 # =============================================================================
@@ -592,9 +610,43 @@ if len(project_datasets) > 1:
     if st.session_state.get("_combine_signature") != _combo_signature:
         st.session_state.pop("working_table", None)
         st.session_state["_combine_signature"] = _combo_signature
+        _ledger.clear()          # a different set of files is a different table
 
-    _combined = render_combine_step(dataframes)
+    # Once a table has been committed, the combine step is HISTORY, not a
+    # control. Re-rendering the full preview on every rerun left its headline
+    # ("→ 156 rows × 10 columns") on screen describing the inputs, directly
+    # above a table that a later cleaning action had reduced to 9 columns —
+    # two different answers to the same question, both looking current.
+    _REOPEN = "_combine_reopen"
+    _committed = (st.session_state.get("working_table") is not None
+                  and not st.session_state.get(_REOPEN))
+    if _committed:
+        st.header("Step 2: Combine your files")
+        _desc = st.session_state.get("_combine_description")
+        st.success(f"**Combined — {len(dataframes)} files into one table.**")
+        if _desc:
+            st.caption(_desc)
+        st.caption("Reopen this only if you want a different join or a different "
+                   "set of files — the table as it stands, including anything "
+                   "you have changed since, is stated in Step 3.")
+        if st.button("Change how these files are combined", key="combine_reopen_btn"):
+            st.session_state[_REOPEN] = True
+            st.rerun()
+        _combined = None
+    else:
+        _combined = render_combine_step(dataframes)
     if _combined is not None:
+        st.session_state.pop(_REOPEN, None)
+        # The account of how this table came to be starts here. `before` is the
+        # file the others were attached to, so the ledger can state the thing a
+        # researcher most wants to know and the join preview only says in
+        # passing: how many of the people you brought are still in the table.
+        _primary = next(iter(dataframes.values())) if dataframes else None
+        _ledger.record(
+            action=f"Combined {len(dataframes)} files",
+            kind=_ledger.COMBINE, before=_primary, after=_combined,
+            detail=st.session_state.get("_combine_description", ""),
+        )
         st.session_state.working_table = _combined
         st.session_state.last_merge_columns = list(_combined.columns)
         set_data(_combined)
@@ -627,6 +679,12 @@ else:
             working_df.columns = [str(c) for c in working_df.columns]
             st.session_state.working_table = working_df
             st.session_state['_working_table_source_id'] = single_dataset['id']
+            _ledger.clear()
+            _ledger.record(
+                action=f"Started from {single_dataset['name']}",
+                kind=_ledger.ADD, before=None, after=working_df,
+                detail=" · ".join(_applied_fix_notes(single_dataset)),
+            )
         else:
             working_df = st.session_state.working_table
         set_data(working_df)
@@ -663,6 +721,16 @@ if len(df) == 0 or len(df.columns) == 0:
 # ============================================================================
 st.markdown("---")
 st.header("Step 3: Data Audit")
+
+# What is being audited, stated where the auditing happens. Without this the
+# only account of the table sat above two committed join previews that still
+# read as live controls, so the most prominent shape on screen could be one the
+# table no longer had.
+_undo_note = st.session_state.pop("_working_table_undo_note", None)
+if _undo_note:
+    st.success(f"↩️ {_undo_note}")
+render_working_table_card(
+    df, "Everything below describes this table, as it stands now.")
 
 from utils.cohort_ui import render_cohort_note as _cohort_note
 _cohort_note("The audit below covers the whole study, which is what it should "
@@ -821,6 +889,10 @@ if suggested_actions:
                     if len(new_df) == 0 or len(new_df.columns) == 0:
                         st.error("This action would result in an empty dataset. Aborted.")
                     else:
+                        _ledger.record(action=label, kind=_ledger.CLEAN,
+                                       before=df, after=new_df,
+                                       detail=(f"Applied to: {', '.join(cols)}"
+                                               if cols else ""))
                         st.session_state.working_table = new_df
                         # Content changed → set_data clears downstream results
                         # (config is kept); reconcile drops any config references
@@ -858,6 +930,16 @@ if suggested_actions:
                     logger.exception(e)
 
 st.session_state.data_audit = audit_results
+
+# ============================================================================
+# SIGN-OFF — the page's closing statement about the DATA, before any question
+# is asked of it. It sits here rather than at the foot of the page because the
+# foot is unreachable until an analysis type is chosen, and the researcher who
+# has not chosen one yet is exactly the one who needs to know what their table
+# holds. Everything earlier on this page is prospective — it explains a
+# decision before you commit to it. Nothing restated the result afterwards.
+# ============================================================================
+render_exit_assurance(get_data(full_study=True))
 
 # ============================================================================
 # SECTION 5: TASK MODE & FIELD SELECTION

--- a/pages/01_Upload_and_Audit.py
+++ b/pages/01_Upload_and_Audit.py
@@ -43,19 +43,23 @@ from ml.eda_recommender import compute_dataset_signals
 logger = logging.getLogger(__name__)
 
 
-def _applied_fix_notes(dataset) -> list:
-    """Import Doctor repairs applied to the file this table came from.
+def _origin_notes(dataset_ids) -> list:
+    """What was done to each file BEFORE it became part of the working table.
 
-    They happen per-file, before the working table exists, so they are carried
-    onto the step that adopts the file rather than lost between the two.
+    Transposing a file and recoding its missing-value codes both change the
+    shape or the values of everything downstream, and both happen per-file
+    while the working table does not yet exist. Carried onto the step that
+    adopts the files so they appear in the account rather than nowhere.
     """
     notes = []
-    try:
-        for _key in (dataset.get('id'), dataset.get('filename'), dataset.get('name')):
-            if _key:
-                notes.extend(applied_fixes(str(_key)))
-    except Exception:
-        pass
+    origins = st.session_state.get("_dataset_origin") or {}
+    for _id in dataset_ids:
+        info = origins.get(_id) or {}
+        name = info.get("filename") or _id
+        if info.get("transposed"):
+            notes.append(f"{name}: transposed (rows and columns swapped on import)")
+        for fix in info.get("repairs") or []:
+            notes.append(f"{name}: {fix}")
     return notes
 
 
@@ -301,12 +305,19 @@ def _log_import_repairs(file_key, dataset_name):
         pass          # recording must never block the upload
 
 
-def _commit_dataset(df, dataset_name, filename, file_type, transposed, replace=True):
+def _commit_dataset(df, dataset_name, filename, file_type, transposed,
+                    replace=True, file_key=None):
     """Register one frame as a dataset in the active project.
 
     Shared by the per-file 'Add' button and the 'Add all' button so both paths
     commit exactly the frame the user reviewed — including any Import Doctor
     fixes — rather than a fresh re-parse of the original file.
+
+    `file_key` is the Import Doctor's session key for this upload. It is taken
+    here because it is the LAST moment the two identities coexist: the Doctor
+    keys its work by "demographics_csv_0" and everything downstream knows the
+    file only by its dataset id, so a repair not carried across right here is
+    invisible from then on.
     """
     existing = db.get_project_datasets(active_project['id'])
     for d in existing:
@@ -331,6 +342,11 @@ def _commit_dataset(df, dataset_name, filename, file_type, transposed, replace=T
         is_transposed=transposed,
     )
     st.session_state.datasets_registry[dataset_id] = df
+    st.session_state.setdefault("_dataset_origin", {})[dataset_id] = {
+        "repairs": list(applied_fixes(file_key)) if file_key else [],
+        "transposed": bool(transposed),
+        "filename": filename,
+    }
     # A new file changes what "combined" means, so any table built from the
     # previous set of files must not survive as the working table.
     st.session_state.pop("working_table", None)
@@ -364,7 +380,8 @@ if uploaded_files and len(uploaded_files) > 1:
                     _name = st.session_state.get(f"name_{_fk}") or _uf.name.rsplit('.', 1)[0]
                     _log_import_repairs(_fk, _name)
                     ok, msg = _commit_dataset(_frame, _name, _uf.name, _ft,
-                                              st.session_state.get(f"transpose_{_fk}", False))
+                                              st.session_state.get(f"transpose_{_fk}", False),
+                                              file_key=_fk)
                     (added if ok else failed).append(msg)
                 except Exception as exc:
                     failed.append(f"{_uf.name}: {exc}")
@@ -530,6 +547,7 @@ if uploaded_files:
                             ok, msg = _commit_dataset(
                                 df_preview, dataset_name, uploaded_file.name,
                                 file_type, transpose_this_file, replace=True,
+                                file_key=file_key,
                             )
                         if not ok:
                             st.error(msg)
@@ -642,10 +660,14 @@ if len(project_datasets) > 1:
         # researcher most wants to know and the join preview only says in
         # passing: how many of the people you brought are still in the table.
         _primary = next(iter(dataframes.values())) if dataframes else None
+        _origin = _origin_notes([d['id'] for d in project_datasets])
         _ledger.record(
             action=f"Combined {len(dataframes)} files",
             kind=_ledger.COMBINE, before=_primary, after=_combined,
-            detail=st.session_state.get("_combine_description", ""),
+            detail=" ".join(filter(None, [
+                st.session_state.get("_combine_description", ""),
+                ("Before combining — " + "; ".join(_origin) + ".") if _origin else "",
+            ])),
         )
         st.session_state.working_table = _combined
         st.session_state.last_merge_columns = list(_combined.columns)
@@ -683,7 +705,7 @@ else:
             _ledger.record(
                 action=f"Started from {single_dataset['name']}",
                 kind=_ledger.ADD, before=None, after=working_df,
-                detail=" · ".join(_applied_fix_notes(single_dataset)),
+                detail=" · ".join(_origin_notes([single_dataset['id']])),
             )
         else:
             working_df = st.session_state.working_table
@@ -691,7 +713,11 @@ else:
         
         st.success(f"**Working Table:** {single_dataset['name']}")
         table(working_df.head(10), width="stretch")
-        st.caption(f"Shape: {working_df.shape[0]:,} rows × {working_df.shape[1]} columns")
+        # The shape is stated once, in the card below, so that there is exactly
+        # one place on this page that answers "what have I got". Repeating it
+        # here invited the two to drift, which is how a stale "× 10 columns"
+        # once sat directly above a live "× 9 columns".
+        st.caption("First 10 rows. What this table holds is summarized below.")
     else:
         st.error("""
         **Dataset not in memory.** 

--- a/tests/test_working_table_is_accounted_for.py
+++ b/tests/test_working_table_is_accounted_for.py
@@ -1,0 +1,273 @@
+"""Upload & Audit has to end with a straight answer about the working table.
+
+Every surface on that page used to be prospective — the join preview explains
+what a merge will do, beautifully, before you commit to it. Nothing restated
+the result afterwards, so:
+
+  - the committed join step went on rendering as a live control, and its
+    headline ("→ 156 rows × 10 columns") described the inputs while sitting
+    directly above a table a cleaning action had reduced to 9 columns;
+  - the number a researcher most needs — that the 60 people they enrolled
+    became 52 in the table — was stated only inside a preview that scrolls
+    away;
+  - a cleaning action's confirmation was a toast, so the account of what had
+    been done to the table survived exactly one interaction;
+  - nothing could be undone.
+
+The ledger is the account. These tests hold it to the arithmetic.
+"""
+import numpy as np
+import pandas as pd
+import pytest
+import streamlit as st
+
+from utils import table_ledger as L
+
+
+@pytest.fixture(autouse=True)
+def clean():
+    st.session_state.clear(); yield; st.session_state.clear()
+
+
+def enrolled(n=60):
+    rng = np.random.default_rng(11)
+    return pd.DataFrame({
+        "subject_id": np.arange(1001, 1001 + n),
+        "age": rng.integers(25, 75, n),
+        "site": "MAIN",                      # constant: the audit offers to drop it
+    })
+
+
+def joined_to_visits(demo, keep=52, visits=3):
+    """The shape an inner join with a repeated-measures file produces."""
+    rng = np.random.default_rng(3)
+    ids = demo["subject_id"].to_numpy()[:keep]
+    return pd.DataFrame({
+        "subject_id": np.repeat(ids, visits),
+        "age": np.repeat(demo["age"].to_numpy()[:keep], visits),
+        "site": "MAIN",
+        "kcal": rng.normal(2100, 400, keep * visits),
+    })
+
+
+# ── the arithmetic ───────────────────────────────────────────────────────
+
+def test_a_join_that_loses_people_says_how_many():
+    demo = enrolled()
+    after = joined_to_visits(demo)
+    L.clear()
+    step = L.record("Combined 3 files", L.COMBINE, before=demo, after=after)
+
+    assert step.subjects_before == 60 and step.subjects_after == 52
+    assert step.subjects_delta == -8
+    assert "lost 8 subjects" in step.cost_sentence()
+    assert step.loss_sentence() == "8 subjects"
+
+
+def test_the_loss_line_does_not_advertise_a_gain():
+    """A join can lose 8 people and gain a column in the same breath."""
+    demo = enrolled()
+    after = joined_to_visits(demo)
+    L.clear()
+    step = L.record("Combined 3 files", L.COMBINE, before=demo, after=after)
+    assert "gained" in step.cost_sentence()          # the full account says both
+    assert "gain" not in step.loss_sentence()        # the losses list says one
+
+
+def test_dropping_a_column_names_it():
+    demo = enrolled()
+    after = demo.drop(columns=["site"])
+    L.clear()
+    step = L.record("Drop constant columns", L.CLEAN, before=demo, after=after)
+    assert step.columns_removed == ["site"]
+    assert "`site`" in step.cost_sentence() and "1 column" in step.cost_sentence()
+    assert step.subjects_delta == 0
+
+
+def test_the_first_step_is_a_starting_point_not_a_gain():
+    """`before=None` means "this is where the table came from"."""
+    demo = enrolled()
+    L.clear()
+    step = L.record("Started from demographics.csv", L.ADD, before=None, after=demo)
+    assert step.rows_before == step.rows_after == 60
+    assert step.cost_sentence() == "" and not step.is_lossy
+
+
+def test_the_net_change_spans_the_whole_account():
+    demo = enrolled()
+    after = joined_to_visits(demo)
+    L.clear()
+    L.record("Combined 3 files", L.COMBINE, before=demo, after=after)
+    L.record("Drop constant columns", L.CLEAN,
+             before=after, after=after.drop(columns=["site"]))
+    net = L.net_change()
+    assert net["rows_before"] == 60 and net["rows_after"] == 156
+    assert net["subjects_before"] == 60 and net["subjects_after"] == 52
+    assert net["cols_before"] == 3 and net["cols_after"] == 3
+    assert net["n_steps"] == 2
+
+
+def test_rows_are_not_people():
+    after = joined_to_visits(enrolled())
+    assert L.subject_column(after) == "subject_id"
+    assert L.count_subjects(after) == 52 and len(after) == 156
+
+
+def test_a_table_with_no_identifier_reports_no_subject_count():
+    """Silence is right here; a guessed n would be worse than none."""
+    df = pd.DataFrame({"bmi": [22.0, 27.5, 31.0], "y": [0, 1, 0]})
+    assert L.subject_column(df) is None
+    assert L.count_subjects(df) is None
+
+
+# ── undo ─────────────────────────────────────────────────────────────────
+
+def test_the_last_step_can_be_undone():
+    demo = enrolled()
+    after = demo.drop(columns=["site"])
+    L.clear()
+    L.record("Drop constant columns", L.CLEAN, before=demo, after=after)
+    assert L.steps()[0].undoable
+
+    back = L.undo_to(0)
+    assert back is not None
+    assert list(back.columns) == list(demo.columns)
+    assert L.steps() == [], "the undone step is still in the account"
+
+
+def test_undo_rolls_back_everything_after_the_chosen_step():
+    demo = enrolled()
+    a = demo.drop(columns=["site"])
+    b = a.drop(columns=["age"])
+    L.clear()
+    L.record("Drop constant columns", L.CLEAN, before=demo, after=a)
+    L.record("Drop age", L.CLEAN, before=a, after=b)
+    assert len(L.steps()) == 2
+
+    back = L.undo_to(0)
+    assert list(back.columns) == list(demo.columns)
+    assert L.steps() == []
+
+
+def test_the_undo_handler_itself_runs():
+    """The ledger's undo worked; the button's handler imported a module that
+    does not exist (`utils.state_reconciler` for `utils.state_reconcile`), so
+    clicking Undo raised before it reached any of it. Exercise the handler, not
+    just the data structure underneath it."""
+    from utils.working_table_ui import _undo
+    demo = enrolled()
+    after = demo.drop(columns=["site"])
+    st.session_state["raw_data"] = after
+    st.session_state["working_table"] = after
+    L.clear()
+    L.record("Drop constant columns", L.CLEAN, before=demo, after=after)
+
+    try:
+        _undo(0)
+    except Exception as exc:                       # st.rerun() raises to stop
+        if type(exc).__name__ not in ("RerunException", "StopException"):
+            raise
+    restored = st.session_state["working_table"]
+    assert "site" in restored.columns, "the undone column did not come back"
+    assert st.session_state.get("_working_table_undo_note"), "the undo was silent"
+
+
+def test_a_table_too_large_to_copy_is_marked_as_not_undoable():
+    """Refused honestly rather than dropped out of the history."""
+    big = pd.DataFrame(np.zeros((2000, 3000)))
+    L.clear()
+    step = L.record("Huge step", L.CLEAN, before=big, after=big.iloc[:, :2999])
+    assert not step.undoable
+    assert L.steps(), "the step must still appear in the account"
+    assert L.undo_to(0) is None
+
+
+# ── the sign-off ─────────────────────────────────────────────────────────
+
+def test_confirming_records_the_shape_it_was_confirmed_at():
+    demo = enrolled()
+    L.confirm(demo)
+    assert L.is_confirmed(demo)
+    assert L.confirmed_shape() == (60, 3)
+
+
+def test_a_confirmation_is_withdrawn_when_the_table_changes():
+    demo = enrolled()
+    L.clear()
+    L.confirm(demo)
+    assert L.is_confirmed(demo)
+
+    after = demo.drop(columns=["site"])
+    L.record("Drop constant columns", L.CLEAN, before=demo, after=after)
+    assert not L.is_confirmed(after), (
+        "a stale tick sat beside changed numbers")
+    assert L.confirmed_shape() is None
+
+
+def test_an_undo_also_withdraws_the_confirmation():
+    demo = enrolled()
+    after = demo.drop(columns=["site"])
+    L.clear()
+    L.record("Drop constant columns", L.CLEAN, before=demo, after=after)
+    L.confirm(after)
+    assert L.is_confirmed(after)
+    L.undo_to(0)
+    assert L.confirmed_shape() is None
+
+
+# ── persistence ──────────────────────────────────────────────────────────
+
+def test_the_account_survives_a_save_and_restore():
+    from utils.session_manager import _collect_session_data, _restore_session_data
+    demo = enrolled()
+    after = joined_to_visits(demo)
+    L.clear()
+    L.record("Combined 3 files", L.COMBINE, before=demo, after=after,
+             detail="inner join on subject_id")
+    L.record("Drop constant columns", L.CLEAN,
+             before=after, after=after.drop(columns=["site"]))
+    st.session_state["raw_data"] = after.drop(columns=["site"])
+
+    archive, _ = _collect_session_data()
+    st.session_state.clear()
+    _restore_session_data(archive)
+
+    back = L.steps()
+    assert len(back) == 2, "the history of the table was lost on restore"
+    assert back[0].subjects_before == 60 and back[0].subjects_after == 52
+    assert back[1].columns_removed == ["site"]
+    assert not any(s.undoable for s in back), (
+        "undo snapshots are session-local and must not claim otherwise")
+
+
+# ── the page wiring ──────────────────────────────────────────────────────
+
+def test_the_committed_combine_step_stops_rendering_as_a_control():
+    """Its headline described the inputs and looked current forever."""
+    src = open("pages/01_Upload_and_Audit.py").read()
+    assert "_combine_reopen" in src
+    assert "Change how these files are combined" in src
+
+
+def test_every_shape_changing_site_records_a_step():
+    import ast
+    src = open("pages/01_Upload_and_Audit.py").read()
+    tree = ast.parse(src)
+    records = [n for n in ast.walk(tree)
+               if isinstance(n, ast.Call)
+               and isinstance(n.func, ast.Attribute)
+               and n.func.attr == "record"
+               and getattr(n.func.value, "id", "") == "_ledger"]
+    assert len(records) >= 3, (
+        f"only {len(records)} mutation sites record a ledger step; the combine, "
+        f"the single-file adopt and the cleaning actions all must")
+
+
+def test_the_page_states_the_table_before_it_asks_what_to_do_with_it():
+    """The sign-off must sit above the st.stop() that gates Step 4."""
+    src = open("pages/01_Upload_and_Audit.py").read()
+    signoff = src.index("render_exit_assurance(")
+    step4 = src.index('st.header("Step 4: Configure Analysis")')
+    assert signoff < step4, (
+        "the sign-off is below the analysis-type gate, so a researcher who has "
+        "not chosen one never sees it")

--- a/tests/test_working_table_is_accounted_for.py
+++ b/tests/test_working_table_is_accounted_for.py
@@ -316,6 +316,83 @@ def test_a_real_repeated_measures_design_still_says_so():
     assert "Your n is 52, not 156" in notes and "3.0 rows" in notes
 
 
+# ── the shape change that hides best ─────────────────────────────────────
+
+def _stacked():
+    """Two cycles sharing most columns — the classic NHANES stack."""
+    from utils.combine_ui import SOURCE_COLUMN
+    rng = np.random.default_rng(2)
+    a = pd.DataFrame({"seqn": np.arange(10001, 10301),
+                      "age": rng.normal(50, 10, 300),
+                      "vitamin_d": rng.normal(60, 15, 300),
+                      "crp": np.nan, SOURCE_COLUMN: "cycle_2017"})
+    b = pd.DataFrame({"seqn": np.arange(20001, 20281),
+                      "age": rng.normal(50, 10, 280),
+                      "vitamin_d": np.nan,
+                      "crp": rng.gamma(2, 1.5, 280), SOURCE_COLUMN: "cycle_2019"})
+    return pd.concat([a, b], ignore_index=True)
+
+
+def test_a_column_measured_in_only_one_file_is_named():
+    """Nothing is empty, nothing is dropped, the row count rises exactly as
+    promised — and half the sample has no value for two of the columns. This
+    used to pass as "nothing about this table looks surprising"."""
+    from utils.working_table_ui import _surprises
+    notes = " ".join(_surprises(_stacked(), None))
+    assert "`vitamin_d` was not measured in cycle_2019" in notes
+    assert "`crp` was not measured in cycle_2017" in notes
+    assert "280 of 580" in notes and "300 of 580" in notes
+
+
+def test_a_column_present_everywhere_is_not_flagged():
+    from utils.working_table_ui import _columns_absent_from_a_source
+    flagged = [c for c, _, _ in _columns_absent_from_a_source(_stacked())]
+    assert "age" not in flagged and "seqn" not in flagged
+
+
+def test_an_unstacked_table_has_no_source_column_to_reason_about():
+    from utils.working_table_ui import _columns_absent_from_a_source
+    assert _columns_absent_from_a_source(enrolled()) == []
+
+
+def test_the_subject_note_never_says_none():
+    """count_subjects re-derives the column when given None; the text has to
+    be attributed to the same one or it reads "`None` repeats"."""
+    from utils.working_table_ui import _surprises
+    notes = " ".join(_surprises(joined_to_visits(enrolled()), None))
+    assert "`None`" not in notes
+
+
+# ── invalidation ─────────────────────────────────────────────────────────
+
+def test_forgetting_the_table_forgets_its_account_too():
+    """Three buttons dropped the table and left the ledger standing. The next
+    combine then appended a second "Combined N files" step to an account that
+    still described the first, giving a chain that did not join up."""
+    import ast
+    src = open("pages/01_Upload_and_Audit.py").read()
+    tree = ast.parse(src)
+    fn = next(n for n in ast.walk(tree)
+              if isinstance(n, ast.FunctionDef) and n.name == "_forget_working_table")
+    body = ast.dump(fn)
+    assert "working_table" in body and "clear" in body
+
+    # every site that drops the working table must go through it
+    drops = [n for n in ast.walk(tree) if isinstance(n, ast.Call)
+             and isinstance(n.func, ast.Attribute) and n.func.attr == "pop"
+             and n.args and isinstance(n.args[0], ast.Constant)
+             and n.args[0].value == "working_table"]
+    assert len(drops) <= 1, (
+        f"{len(drops)} places pop working_table directly; they must call "
+        f"_forget_working_table so the ledger goes with it")
+
+
+def test_removing_a_file_says_what_it_costs():
+    src = open("pages/01_Upload_and_Audit.py").read()
+    assert "is discarded and you will combine the remaining files" in src, (
+        "Remove destroys the working table on one unlabeled click")
+
+
 # ── the page wiring ──────────────────────────────────────────────────────
 
 def test_the_committed_combine_step_stops_rendering_as_a_control():

--- a/tests/test_working_table_is_accounted_for.py
+++ b/tests/test_working_table_is_accounted_for.py
@@ -240,6 +240,82 @@ def test_the_account_survives_a_save_and_restore():
         "undo snapshots are session-local and must not claim otherwise")
 
 
+# ── what happened to the files before the table existed ──────────────────
+
+def test_a_transpose_and_a_repair_reach_the_sign_off():
+    """Both happen per-file, and neither shows up in any before/after count.
+
+    A transpose inverts the table; a recode rewrites values in place. The
+    first version looked repairs up by dataset id, filename and name — but the
+    Import Doctor keys its work by "demographics_csv_0", so nothing ever
+    matched and both were invisible from the moment the file was committed.
+    """
+    from utils.working_table_ui import _surprises
+    df = enrolled()
+    st.session_state["_dataset_origin"] = {
+        "d1": {"filename": "ffq_wide.csv", "transposed": True, "repairs": []},
+        "d2": {"filename": "survey.csv", "transposed": False,
+               "repairs": ["Recoded 999999 to missing in `income`"]},
+    }
+    notes = " ".join(_surprises(df, "subject_id"))
+    assert "transposed on import" in notes and "ffq_wide.csv" in notes
+    assert "value-level repair" in notes and "income" in notes
+
+
+def test_the_commit_carries_the_import_doctor_key():
+    """The last moment the file key and the dataset id coexist."""
+    import ast
+    src = open("pages/01_Upload_and_Audit.py").read()
+    tree = ast.parse(src)
+    fn = next(n for n in ast.walk(tree)
+              if isinstance(n, ast.FunctionDef) and n.name == "_commit_dataset")
+    assert any(a.arg == "file_key" for a in fn.args.args + fn.args.kwonlyargs), (
+        "_commit_dataset cannot record repairs it is never told about")
+    calls = [n for n in ast.walk(tree) if isinstance(n, ast.Call)
+             and getattr(n.func, "id", "") == "_commit_dataset"]
+    upload_calls = [c for c in calls if any(k.arg == "file_key" for k in c.keywords)]
+    assert len(upload_calls) >= 2, (
+        f"{len(upload_calls)} of {len(calls)} commit sites pass a file key; both "
+        f"upload paths must")
+
+
+# ── one place answers "what have I got" ──────────────────────────────────
+
+def test_only_the_card_states_the_shape():
+    """Two places invited the drift this whole change exists to end."""
+    page = open("pages/01_Upload_and_Audit.py").read()
+    combine = open("utils/combine_ui.py").read()
+    assert "Combined table ready" not in combine, (
+        "the combine summary restates the shape beside the card")
+    assert 'st.caption(f"Shape: {working_df.shape[0]:,} rows' not in page, (
+        "Step 2 restates the shape beside the card")
+
+
+def test_a_step_that_changed_nothing_does_not_draw_an_arrow():
+    demo = enrolled()
+    L.clear()
+    step = L.record("Started from study.csv", L.ADD, before=None, after=demo)
+    assert "→" not in step.shape_sentence()
+    assert step.shape_sentence() == "60 × 3"
+
+
+def test_a_handful_of_repeats_is_not_reported_as_repeated_measures():
+    """"each person contributes about 1.0 rows" is noise, not information."""
+    from utils.working_table_ui import _surprises
+    demo = enrolled()
+    with_dupes = pd.concat([demo, demo.iloc[:12]], ignore_index=True)
+    notes = " ".join(_surprises(with_dupes, "subject_id"))
+    assert "1.0 rows" not in notes
+    assert "share a `subject_id` with another row" in notes
+
+
+def test_a_real_repeated_measures_design_still_says_so():
+    from utils.working_table_ui import _surprises
+    after = joined_to_visits(enrolled())
+    notes = " ".join(_surprises(after, "subject_id"))
+    assert "Your n is 52, not 156" in notes and "3.0 rows" in notes
+
+
 # ── the page wiring ──────────────────────────────────────────────────────
 
 def test_the_committed_combine_step_stops_rendering_as_a_control():

--- a/utils/combine_ui.py
+++ b/utils/combine_ui.py
@@ -510,11 +510,15 @@ def render_combine_step(frames: Dict[str, pd.DataFrame]) -> Optional[pd.DataFram
 
 
 def render_combined_summary(df: pd.DataFrame) -> None:
-    """After combining: what you got, and where it came from."""
-    desc = st.session_state.get("_combine_description")
-    st.success(f"**Combined table ready** — {len(df):,} rows × {df.shape[1]} columns")
-    if desc:
-        st.caption(desc)
+    """Where the combined rows came from.
+
+    The shape and the description are deliberately NOT repeated here. The
+    working-table card states the shape once, so there is a single place on the
+    page that answers "what have I got" — two places invited exactly the drift
+    that once left a stale "× 10 columns" sitting above a live "× 9 columns".
+    What only this function knows is the per-file breakdown, so that is what it
+    says.
+    """
     if SOURCE_COLUMN in df.columns:
         counts = df[SOURCE_COLUMN].value_counts()
         st.caption("Rows per file: " +

--- a/utils/session_manager.py
+++ b/utils/session_manager.py
@@ -414,6 +414,19 @@ def _build_archive_members() -> Dict[str, bytes]:
         except Exception:
             skipped_keys.append("fe_recipe")
 
+    # How the working table came to be. Restoring the table without its account
+    # would put the researcher back in front of numbers with no explanation of
+    # where they came from — which is the state this ledger exists to end.
+    try:
+        from utils import table_ledger as _tl
+        _ledger_rows = _tl.to_list()
+        if _ledger_rows:
+            members["table_ledger.json"] = json.dumps(
+                _ledger_rows, indent=2, default=str).encode("utf-8")
+            saved_keys.append("working_table_ledger")
+    except Exception:
+        skipped_keys.append("working_table_ledger")
+
     # --- Coach evidence probe (schema 2.1) ---
     probe = st.session_state.get("coach_probe_result")
     if probe is not None and is_dataclass(probe):
@@ -760,6 +773,17 @@ def _restore_session_data(archive_bytes: bytes) -> Tuple[int, Dict[str, Any], li
                     f"The feature-engineering recipe could not be restored "
                     f"({exc}). Switching cohorts will not rebuild your "
                     f"engineered features until you recreate them.")
+
+        if "table_ledger.json" in names:
+            try:
+                from utils import table_ledger as _tl
+                _tl.from_list(_read_json(zf, "table_ledger.json"))
+                restored += 1
+            except Exception as exc:
+                warnings.append(
+                    f"The record of how your working table was assembled could "
+                    f"not be restored ({exc}). The table itself is unchanged; "
+                    f"only its history is missing.")
 
         # --- Test-set lockbox (schema 2.1; absent in 2.0 files) ---
         if "lockbox.json" in names:

--- a/utils/table_ledger.py
+++ b/utils/table_ledger.py
@@ -124,8 +124,14 @@ class Step:
         return ", ".join(parts)
 
     def shape_sentence(self) -> str:
-        return (f"{self.rows_before:,} × {self.cols_before} "
-                f"→ {self.rows_after:,} × {self.cols_after}")
+        """An arrow only where something actually moved.
+
+        "412 × 6 → 412 × 6" is a strange way to say a file was opened.
+        """
+        after = f"{self.rows_after:,} × {self.cols_after}"
+        if (self.rows_before, self.cols_before) == (self.rows_after, self.cols_after):
+            return after
+        return f"{self.rows_before:,} × {self.cols_before} → {after}"
 
 
 # ── identity ─────────────────────────────────────────────────────────────

--- a/utils/table_ledger.py
+++ b/utils/table_ledger.py
@@ -1,0 +1,351 @@
+"""What the working table is, and every decision that made it that way.
+
+Upload & Audit is very good at explaining a decision BEFORE you commit to it —
+the join preview says what will be kept, what will be dropped, and what it will
+do to your n. It has had nothing to say afterwards. Committed steps stayed on
+screen still dressed as live controls, so a table that had since lost a column
+was described by a headline reading "156 rows x 10 columns" directly above a
+line reading "156 rows x 9 columns". The one number a researcher most needs —
+that the 60 people they enrolled became 52 in the table — appeared only inside
+a preview that scrolls away.
+
+So this module keeps the account. Every action that changes the shape of the
+working table records a Step here, in order, with what it cost. The page reads
+it back as a standing statement of what you have and how you got it, and, where
+the frame was small enough to hold onto, as an undo.
+
+Rows are not people. Where an identifier is present the ledger tracks distinct
+subjects alongside rows, because a repeated-measures join multiplies rows while
+holding subjects flat, and "156" is then the wrong answer to "how big is my
+study".
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field, asdict
+from typing import Any, Dict, List, Optional, Tuple
+
+import pandas as pd
+
+_LEDGER_KEY = "working_table_ledger"
+_CONFIRM_KEY = "working_table_confirmed_shape"
+_SNAPSHOT_KEY = "_working_table_snapshots"
+
+# Undo keeps a copy of the previous frame. On an omics file that is expensive,
+# so it is offered only where it is affordable and refused honestly elsewhere
+# rather than silently dropping steps out of the history.
+_MAX_UNDO_CELLS = 4_000_000
+_MAX_UNDO_STEPS = 8
+
+# Kinds of change, so the card can rank what is worth saying out loud.
+ADD = "add"                 # a file became the working table
+COMBINE = "combine"         # a join or a stack
+REPAIR = "repair"           # an Import Doctor fix
+CLEAN = "clean"             # a suggested action on the audit
+RESHAPE = "reshape"         # transpose, header promotion
+
+
+@dataclass
+class Step:
+    """One decision, and what it did to the table."""
+    action: str
+    kind: str
+    rows_before: int
+    rows_after: int
+    cols_before: int
+    cols_after: int
+    detail: str = ""
+    subjects_before: Optional[int] = None
+    subjects_after: Optional[int] = None
+    columns_removed: List[str] = field(default_factory=list)
+    columns_added: List[str] = field(default_factory=list)
+    undoable: bool = False
+
+    # -- what it cost, in the words the card uses ------------------------
+    @property
+    def rows_delta(self) -> int:
+        return self.rows_after - self.rows_before
+
+    @property
+    def cols_delta(self) -> int:
+        return self.cols_after - self.cols_before
+
+    @property
+    def subjects_delta(self) -> Optional[int]:
+        if self.subjects_before is None or self.subjects_after is None:
+            return None
+        return self.subjects_after - self.subjects_before
+
+    @property
+    def is_lossy(self) -> bool:
+        """True when this step removed rows, subjects, or columns."""
+        return (self.rows_delta < 0 or self.cols_delta < 0
+                or (self.subjects_delta or 0) < 0)
+
+    def cost_sentence(self) -> str:
+        """The plain arithmetic, or "" when nothing about the shape moved."""
+        parts: List[str] = []
+        if self.rows_delta:
+            verb = "lost" if self.rows_delta < 0 else "gained"
+            parts.append(f"{verb} {abs(self.rows_delta):,} row"
+                         f"{'' if abs(self.rows_delta) == 1 else 's'}")
+        sd = self.subjects_delta
+        if sd:
+            verb = "lost" if sd < 0 else "gained"
+            parts.append(f"{verb} {abs(sd):,} subject{'' if abs(sd) == 1 else 's'}")
+        if self.cols_delta:
+            verb = "lost" if self.cols_delta < 0 else "gained"
+            named = ", ".join(f"`{c}`" for c in
+                              (self.columns_removed if self.cols_delta < 0
+                               else self.columns_added)[:4])
+            tail = f" ({named})" if named else ""
+            parts.append(f"{verb} {abs(self.cols_delta):,} column"
+                         f"{'' if abs(self.cols_delta) == 1 else 's'}{tail}")
+        return ", ".join(parts)
+
+    def loss_sentence(self) -> str:
+        """Only what this step took away.
+
+        A join can lose 8 people and gain 5 columns in the same breath, so the
+        card's "what you no longer have" list has to say the first half without
+        the second, or it reads as a gain.
+        """
+        parts: List[str] = []
+        sd = self.subjects_delta
+        if sd and sd < 0:
+            parts.append(f"{abs(sd):,} subject{'' if abs(sd) == 1 else 's'}")
+        if self.rows_delta < 0:
+            parts.append(f"{abs(self.rows_delta):,} row"
+                         f"{'' if abs(self.rows_delta) == 1 else 's'}")
+        if self.cols_delta < 0:
+            named = ", ".join(f"`{c}`" for c in self.columns_removed[:4])
+            tail = f" ({named})" if named else ""
+            parts.append(f"{abs(self.cols_delta):,} column"
+                         f"{'' if abs(self.cols_delta) == 1 else 's'}{tail}")
+        return ", ".join(parts)
+
+    def shape_sentence(self) -> str:
+        return (f"{self.rows_before:,} × {self.cols_before} "
+                f"→ {self.rows_after:,} × {self.cols_after}")
+
+
+# ── identity ─────────────────────────────────────────────────────────────
+
+def subject_column(df: Optional[pd.DataFrame]) -> Optional[str]:
+    """The column that names a person, when one is recognizable.
+
+    Reuses the lockbox's ranking so the ledger, the split, and the chip all
+    mean the same thing by "subject" — three different answers on one page
+    would be worse than none.
+    """
+    if df is None or df.empty:
+        return None
+    try:
+        from utils.test_lockbox import rank_grouping_candidates, _id_kind
+        ranked = rank_grouping_candidates(df)
+        for cand in ranked:
+            if cand["kind"] == "subject":
+                return cand["column"]
+        # a near-unique ID column does not repeat, so ranking skips it
+        for col in df.columns:
+            if _id_kind(col) == "subject":
+                return str(col)
+    except Exception:
+        pass
+    return None
+
+
+def count_subjects(df: Optional[pd.DataFrame],
+                   col: Optional[str] = None) -> Optional[int]:
+    """Distinct subjects in `df`, or None when nothing identifies one."""
+    if df is None:
+        return None
+    col = col or subject_column(df)
+    if not col or col not in df.columns:
+        return None
+    try:
+        return int(df[col].nunique(dropna=True))
+    except Exception:
+        return None
+
+
+def shape_of(df: Optional[pd.DataFrame]) -> Tuple[int, int]:
+    if df is None:
+        return (0, 0)
+    return (int(df.shape[0]), int(df.shape[1]))
+
+
+# ── the ledger ───────────────────────────────────────────────────────────
+
+def steps() -> List[Step]:
+    import streamlit as st
+    raw = st.session_state.get(_LEDGER_KEY) or []
+    return [s for s in raw if isinstance(s, Step)]
+
+
+def clear() -> None:
+    """Start a new account. Called when the project's files change."""
+    import streamlit as st
+    st.session_state.pop(_LEDGER_KEY, None)
+    st.session_state.pop(_SNAPSHOT_KEY, None)
+    st.session_state.pop(_CONFIRM_KEY, None)
+
+
+def record(action: str, kind: str,
+           before: Optional[pd.DataFrame], after: Optional[pd.DataFrame],
+           detail: str = "", subject_col: Optional[str] = None) -> Step:
+    """Add a step, measuring the cost from the two frames themselves.
+
+    Measuring rather than trusting a caller's numbers is deliberate: the
+    caller that reported `rows_before=0, rows_after=0` for an in-place recode
+    is exactly how the study N was once overwritten with zero.
+    """
+    import streamlit as st
+    ra, ca = shape_of(after)
+    # `before=None` means "this is where the table came from" — the first file
+    # adopted, with nothing before it. Recording 0 -> 156 there would put
+    # "gained 156 rows" at the head of the account, which reads as a change
+    # rather than a starting point.
+    origin_step = before is None
+    rb, cb = (ra, ca) if origin_step else shape_of(before)
+    col = subject_col or subject_column(after if after is not None else before)
+    before_cols = set(after.columns) if origin_step else (
+        set(before.columns) if before is not None else set())
+    after_cols = set(after.columns) if after is not None else set()
+
+    step = Step(
+        action=action, kind=kind,
+        rows_before=rb, rows_after=ra, cols_before=cb, cols_after=ca,
+        detail=detail,
+        subjects_before=count_subjects(after if origin_step else before, col),
+        subjects_after=count_subjects(after, col),
+        columns_removed=sorted(str(c) for c in before_cols - after_cols),
+        columns_added=sorted(str(c) for c in after_cols - before_cols),
+    )
+    step.undoable = _keep_snapshot(before, len(steps()))
+
+    st.session_state[_LEDGER_KEY] = steps() + [step]
+    # The table moved, so any confirmation the researcher gave describes a
+    # table that no longer exists. Withdraw it rather than let a stale tick
+    # sit beside changed numbers.
+    _withdraw_confirmation_if_shape_moved((ra, ca))
+    return step
+
+
+def _keep_snapshot(before: Optional[pd.DataFrame], index: int) -> bool:
+    import streamlit as st
+    if before is None:
+        return False
+    rows, cols = shape_of(before)
+    if rows * max(cols, 1) > _MAX_UNDO_CELLS:
+        return False
+    snaps: Dict[int, pd.DataFrame] = st.session_state.get(_SNAPSHOT_KEY) or {}
+    snaps[index] = before.copy()
+    for old in sorted(snaps)[:-_MAX_UNDO_STEPS]:
+        snaps.pop(old, None)
+    st.session_state[_SNAPSHOT_KEY] = snaps
+    return True
+
+
+def snapshot_for(index: int) -> Optional[pd.DataFrame]:
+    """The frame as it stood BEFORE step `index`, when it was cheap to keep."""
+    import streamlit as st
+    snaps = st.session_state.get(_SNAPSHOT_KEY) or {}
+    frame = snaps.get(index)
+    return frame.copy() if frame is not None else None
+
+
+def undo_to(index: int) -> Optional[pd.DataFrame]:
+    """Roll the ledger back to just before step `index` and return that frame."""
+    import streamlit as st
+    frame = snapshot_for(index)
+    if frame is None:
+        return None
+    st.session_state[_LEDGER_KEY] = steps()[:index]
+    snaps = st.session_state.get(_SNAPSHOT_KEY) or {}
+    st.session_state[_SNAPSHOT_KEY] = {k: v for k, v in snaps.items() if k < index}
+    st.session_state.pop(_CONFIRM_KEY, None)
+    return frame
+
+
+# ── the account, summarized ──────────────────────────────────────────────
+
+def origin() -> Optional[Step]:
+    return steps()[0] if steps() else None
+
+
+def lossy_steps() -> List[Step]:
+    return [s for s in steps() if s.is_lossy]
+
+
+def net_change() -> Optional[Dict[str, Any]]:
+    """From the first thing brought in to the table as it stands now."""
+    all_steps = steps()
+    if not all_steps:
+        return None
+    first, last = all_steps[0], all_steps[-1]
+    return {
+        "rows_before": first.rows_before, "rows_after": last.rows_after,
+        "cols_before": first.cols_before, "cols_after": last.cols_after,
+        "subjects_before": first.subjects_before,
+        "subjects_after": last.subjects_after,
+        "n_steps": len(all_steps),
+    }
+
+
+# ── the researcher's sign-off ────────────────────────────────────────────
+
+def confirm(df: Optional[pd.DataFrame]) -> None:
+    import streamlit as st
+    st.session_state[_CONFIRM_KEY] = shape_of(df)
+
+
+def withdraw_confirmation() -> None:
+    import streamlit as st
+    st.session_state.pop(_CONFIRM_KEY, None)
+
+
+def confirmed_shape() -> Optional[Tuple[int, int]]:
+    import streamlit as st
+    val = st.session_state.get(_CONFIRM_KEY)
+    if isinstance(val, (list, tuple)) and len(val) == 2:
+        return (int(val[0]), int(val[1]))
+    return None
+
+
+def is_confirmed(df: Optional[pd.DataFrame]) -> bool:
+    """True only when the table still has the shape that was signed off."""
+    want = confirmed_shape()
+    return want is not None and want == shape_of(df)
+
+
+def _withdraw_confirmation_if_shape_moved(new_shape: Tuple[int, int]) -> None:
+    want = confirmed_shape()
+    if want is not None and want != new_shape:
+        withdraw_confirmation()
+
+
+# ── persistence ──────────────────────────────────────────────────────────
+
+def to_list() -> List[Dict[str, Any]]:
+    """Serializable ledger. Snapshots are NOT saved — undo is session-local."""
+    out = []
+    for s in steps():
+        d = asdict(s)
+        d["undoable"] = False
+        out.append(d)
+    return out
+
+
+def from_list(data: Any) -> None:
+    import streamlit as st
+    restored: List[Step] = []
+    for d in data or []:
+        if not isinstance(d, dict):
+            continue
+        try:
+            restored.append(Step(**{k: v for k, v in d.items()
+                                    if k in Step.__dataclass_fields__}))
+        except Exception:
+            continue
+    if restored:
+        st.session_state[_LEDGER_KEY] = restored

--- a/utils/working_table_ui.py
+++ b/utils/working_table_ui.py
@@ -128,6 +128,38 @@ def _undo(index: int) -> None:
 
 # ── the closing statement ────────────────────────────────────────────────
 
+def _columns_absent_from_a_source(df: pd.DataFrame) -> list:
+    """Columns that are wholly missing from at least one contributing file.
+
+    Returns (column, files_it_is_missing_from, files_it_came_from). Only
+    meaningful for a stacked table, which is the only place the source of each
+    row is recorded.
+    """
+    try:
+        from utils.combine_ui import SOURCE_COLUMN
+    except Exception:
+        return []
+    if SOURCE_COLUMN not in df.columns:
+        return []
+    out = []
+    try:
+        sources = [str(s) for s in df[SOURCE_COLUMN].dropna().unique()]
+        if len(sources) < 2:
+            return []
+        for col in df.columns:
+            if str(col) == SOURCE_COLUMN or not df[col].isna().any():
+                continue
+            absent, present = [], []
+            for src in sources:
+                rows = df.loc[df[SOURCE_COLUMN].astype(str) == src, col]
+                (absent if rows.isna().all() else present).append(src)
+            if absent and present:
+                out.append((str(col), absent, present))
+    except Exception:
+        return []
+    return out
+
+
 def _surprises(df: pd.DataFrame, subj_col: Optional[str]) -> list:
     """Things true of this table that a researcher would want to have noticed.
 
@@ -136,6 +168,10 @@ def _surprises(df: pd.DataFrame, subj_col: Optional[str]) -> list:
     """
     out = []
     rows, cols = ledger.shape_of(df)
+    # count_subjects re-derives the column when given None, so resolving it
+    # here keeps the number and the name it is attributed to in agreement —
+    # without this the note read "`None` repeats".
+    subj_col = subj_col or ledger.subject_column(df)
 
     n_sub = ledger.count_subjects(df, subj_col)
     if n_sub is not None and n_sub < rows:
@@ -191,6 +227,21 @@ def _surprises(df: pd.DataFrame, subj_col: Optional[str]) -> list:
             + ", ".join(f"`{c}`" for c in dropped[:8])
             + ("…" if len(dropped) > 8 else "")
             + f". {'It is' if one else 'They are'} not available to any later step."
+        )
+
+    # Stacking files with different columns is the shape change that hides
+    # best. Nothing is empty, nothing is dropped, the row count goes up exactly
+    # as promised — and a column measured in only one of the files is now
+    # missing for every row from the others. A researcher who models it loses
+    # half their sample and finds out, if at all, from a sample size in a
+    # results table. This used to pass as "nothing about this table looks
+    # surprising".
+    for col, absent_from, present_in in _columns_absent_from_a_source(df):
+        out.append(
+            f"**`{col}` was not measured in {', '.join(absent_from)}.** It is "
+            f"missing for every one of those rows — {int(df[col].isna().sum()):,} "
+            f"of {rows:,} — and present only in {', '.join(present_in)}. Modeling "
+            f"it silently restricts your sample to those files."
         )
 
     empty_cols = [c for c in df.columns if df[c].isna().all()]

--- a/utils/working_table_ui.py
+++ b/utils/working_table_ui.py
@@ -1,0 +1,233 @@
+"""The standing statement of what the working table is.
+
+Two surfaces, both reading the same ledger:
+
+`render_working_table_card` sits at the head of the audit, because the audit is
+about THIS table and the researcher should not have to scroll up through two
+committed join previews to find out what it currently holds.
+
+`render_exit_assurance` closes the page. It restates the table, names anything
+about it a researcher would want to have noticed, and asks for a sign-off that
+is withdrawn automatically if the table moves afterwards. Leaving Upload &
+Audit should feel like signing for a delivery, not like hoping.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+import pandas as pd
+import streamlit as st
+
+from utils import table_ledger as ledger
+
+
+def _shape_line(df: pd.DataFrame, subj_col: Optional[str]) -> str:
+    rows, cols = ledger.shape_of(df)
+    line = f"**{rows:,} rows × {cols} columns**"
+    n_sub = ledger.count_subjects(df, subj_col)
+    if n_sub is not None and n_sub != rows:
+        # Rows are not people. A repeated-measures join multiplies rows while
+        # subjects stay flat, and reporting only rows invites a study to be
+        # written up with the wrong n.
+        line += f" — {n_sub:,} distinct `{subj_col}` values across those rows"
+    return line
+
+
+def render_working_table_card(df: Optional[pd.DataFrame],
+                              context: str = "") -> None:
+    """What you have, how it got that way, and how to take a step back."""
+    if df is None or df.empty:
+        return
+    subj_col = ledger.subject_column(df)
+    all_steps = ledger.steps()
+
+    with st.container(border=True):
+        st.markdown(f"#### 📋 Your working table\n{_shape_line(df, subj_col)}")
+        if context:
+            st.caption(context)
+
+        net = ledger.net_change()
+        if net and net["n_steps"]:
+            bits = []
+            if net["rows_before"] != net["rows_after"]:
+                bits.append(f"{net['rows_before']:,} → {net['rows_after']:,} rows")
+            if net["cols_before"] != net["cols_after"]:
+                bits.append(f"{net['cols_before']} → {net['cols_after']} columns")
+            if (net["subjects_before"] is not None
+                    and net["subjects_after"] is not None
+                    and net["subjects_before"] != net["subjects_after"]):
+                bits.append(f"{net['subjects_before']:,} → "
+                            f"{net['subjects_after']:,} subjects")
+            if bits:
+                st.caption("Since the first file you added: " + " · ".join(bits))
+
+        lossy = [(s, s.loss_sentence()) for s in ledger.lossy_steps()]
+        lossy = [(s, loss) for s, loss in lossy if loss]
+        if lossy:
+            st.markdown("**What you no longer have**")
+            for s, loss in lossy:
+                st.markdown(f"- **{loss}** — {s.action}")
+
+        if all_steps:
+            with st.expander(f"Every step that shaped this table ({len(all_steps)})",
+                             expanded=False):
+                _render_lineage(all_steps)
+
+
+def _render_lineage(all_steps) -> None:
+    """The ordered account, with an undo where one is affordable."""
+    for i, s in enumerate(all_steps):
+        left, right = st.columns([5, 1])
+        with left:
+            st.markdown(f"**{i + 1}. {s.action}** — {s.shape_sentence()}")
+            cost = s.cost_sentence()
+            if cost:
+                st.caption(("⚠️ " if s.is_lossy else "") + cost)
+            if s.detail:
+                st.caption(s.detail)
+        with right:
+            if s.undoable and i == len(all_steps) - 1:
+                if st.button("Undo", key=f"wt_undo_{i}",
+                             help="Put the table back as it was before this step"):
+                    _undo(i)
+            elif s.undoable:
+                if st.button("Back to here", key=f"wt_undo_{i}",
+                             help=f"Undo this and the {len(all_steps) - i - 1} "
+                                  f"step(s) after it"):
+                    _undo(i)
+    if any(not s.undoable for s in all_steps):
+        st.caption(
+            "Steps without an undo button cannot be reversed here — either they "
+            "happened before the table existed, or the table was too large to "
+            "keep a copy of. Re-add the file to start over."
+        )
+
+
+def _undo(index: int) -> None:
+    from utils.session_state import set_data
+    from utils.state_reconcile import reconcile_state_with_df
+
+    frame = ledger.undo_to(index)
+    if frame is None:
+        st.warning("That step cannot be undone — no copy of the earlier table was kept.")
+        return
+    st.session_state["working_table"] = frame
+    # A restored table has the columns the undone step removed, so this is a
+    # schema change in the direction that matters: anything downstream that was
+    # narrowed to fit the smaller table has to be let back out.
+    set_data(frame)
+    try:
+        reconcile_state_with_df(frame, st.session_state)
+    except Exception:
+        pass
+    st.session_state["_working_table_undo_note"] = (
+        f"Undone. The table is back to {len(frame):,} rows × {frame.shape[1]} columns."
+    )
+    st.rerun()
+
+
+# ── the closing statement ────────────────────────────────────────────────
+
+def _surprises(df: pd.DataFrame, subj_col: Optional[str]) -> list:
+    """Things true of this table that a researcher would want to have noticed.
+
+    Every one of these is legitimate and may be exactly what was intended. The
+    point is that none of them should be discovered later, in a result.
+    """
+    out = []
+    rows, cols = ledger.shape_of(df)
+
+    n_sub = ledger.count_subjects(df, subj_col)
+    if n_sub is not None and n_sub < rows:
+        out.append(
+            f"**Your n is {n_sub:,}, not {rows:,}.** `{subj_col}` repeats — each "
+            f"person contributes about {rows / max(n_sub, 1):.1f} rows. Anything "
+            f"averaged over rows weights people by how many measurements they "
+            f"have, and the held-out set is split by person for the same reason."
+        )
+
+    net = ledger.net_change()
+    if net and net["subjects_before"] and net["subjects_after"] is not None:
+        lost = net["subjects_before"] - net["subjects_after"]
+        if lost > 0:
+            pct = 100 * lost / max(net["subjects_before"], 1)
+            out.append(
+                f"**{lost:,} of the {net['subjects_before']:,} people you started "
+                f"with ({pct:.0f}%) are not in this table.** If being present in "
+                f"every file is related to what you are predicting, the people "
+                f"who remain are a selected sample."
+            )
+
+    dropped = [c for s in ledger.steps() for c in s.columns_removed]
+    if dropped:
+        one = len(dropped) == 1
+        out.append(
+            f"**{len(dropped)} column{'' if one else 's'} "
+            f"{'was' if one else 'were'} removed:** "
+            + ", ".join(f"`{c}`" for c in dropped[:8])
+            + ("…" if len(dropped) > 8 else "")
+            + f". {'It is' if one else 'They are'} not available to any later step."
+        )
+
+    empty_cols = [c for c in df.columns if df[c].isna().all()]
+    if empty_cols:
+        one = len(empty_cols) == 1
+        out.append(
+            f"**{len(empty_cols)} column{'' if one else 's'} "
+            f"{'is' if one else 'are'} entirely empty** ("
+            + ", ".join(f"`{c}`" for c in empty_cols[:6])
+            + f"). Stacking files with different columns does this; "
+              f"{'it carries' if one else 'they carry'} no information and "
+              f"cannot be modeled."
+        )
+
+    dupes = int(df.duplicated().sum())
+    if dupes:
+        out.append(f"**{dupes:,} rows are exact duplicates** of another row.")
+
+    return out
+
+
+def render_exit_assurance(df: Optional[pd.DataFrame]) -> None:
+    """The sign-off. Restate the table, name what is notable, ask for a yes."""
+    if df is None or df.empty:
+        return
+    subj_col = ledger.subject_column(df)
+    rows, cols = ledger.shape_of(df)
+
+    st.markdown("---")
+    st.markdown("### Is this the data you meant?")
+    with st.container(border=True):
+        st.markdown(
+            f"Everything from here on — the plots, the models, the numbers in "
+            f"your manuscript — describes this table and nothing else.\n\n"
+            f"{_shape_line(df, subj_col)}"
+        )
+
+        notes = _surprises(df, subj_col)
+        if notes:
+            st.markdown("**Worth knowing before you continue**")
+            for n in notes:
+                st.markdown(f"- {n}")
+        else:
+            st.caption("Nothing about this table looks surprising.")
+
+        already = ledger.is_confirmed(df)
+        checked = st.checkbox(
+            "This is the table I want to analyze.",
+            value=already, key="wt_confirm_box",
+            help="Recorded with the table's current shape. If the table changes "
+                 "afterwards, this is withdrawn and you will be asked again.",
+        )
+        if checked and not already:
+            ledger.confirm(df)
+        elif not checked and already:
+            ledger.withdraw_confirmation()
+
+        prior = ledger.confirmed_shape()
+        if prior is not None and prior != (rows, cols):
+            st.warning(
+                f"⚠️ You confirmed a table of {prior[0]:,} rows × {prior[1]} "
+                f"columns. It is now {rows:,} × {cols}. Check the change above "
+                f"and confirm again."
+            )

--- a/utils/working_table_ui.py
+++ b/utils/working_table_ui.py
@@ -139,12 +139,36 @@ def _surprises(df: pd.DataFrame, subj_col: Optional[str]) -> list:
 
     n_sub = ledger.count_subjects(df, subj_col)
     if n_sub is not None and n_sub < rows:
-        out.append(
-            f"**Your n is {n_sub:,}, not {rows:,}.** `{subj_col}` repeats — each "
-            f"person contributes about {rows / max(n_sub, 1):.1f} rows. Anything "
-            f"averaged over rows weights people by how many measurements they "
-            f"have, and the held-out set is split by person for the same reason."
-        )
+        per = rows / max(n_sub, 1)
+        # What separates a repeated-measures design from a few stray duplicates
+        # is not the average rows per person — 1.2 can mean "every subject has
+        # 1.2 visits", which is impossible, or "a fifth of them are duplicated",
+        # which is a data problem. It is whether repetition is systematic.
+        try:
+            counts = df[subj_col].value_counts()
+            share_repeating = float((counts > 1).sum()) / max(len(counts), 1)
+        except Exception:
+            share_repeating = 1.0 if per >= 1.2 else 0.0
+        if share_repeating >= 0.5:
+            # A genuine repeated-measures design.
+            out.append(
+                f"**Your n is {n_sub:,}, not {rows:,}.** `{subj_col}` repeats — "
+                f"each person contributes about {per:.1f} rows. Anything averaged "
+                f"over rows weights people by how many measurements they have, "
+                f"and the held-out set is split by person for the same reason."
+            )
+        else:
+            # A handful of repeats. Saying "each person contributes about 1.0
+            # rows" is noise, and the duplicate-row line below tells the real
+            # story — but the count still matters, because it is what makes the
+            # split subject-aware.
+            extra = rows - n_sub
+            out.append(
+                f"**{extra:,} row{'' if extra == 1 else 's'} share a "
+                f"`{subj_col}` with another row**, so this table holds {n_sub:,} "
+                f"people in {rows:,} rows. The held-out set is split by person, "
+                f"not by row, because of it."
+            )
 
     net = ledger.net_change()
     if net and net["subjects_before"] and net["subjects_after"] is not None:
@@ -184,6 +208,36 @@ def _surprises(df: pd.DataFrame, subj_col: Optional[str]) -> list:
     dupes = int(df.duplicated().sum())
     if dupes:
         out.append(f"**{dupes:,} rows are exact duplicates** of another row.")
+
+    # Two choices made per-file, before this table existed, that change what
+    # every number here means. A transpose inverts the table outright; a
+    # recode rewrites values in place and leaves the shape untouched, so
+    # neither shows up in any before/after count.
+    origins = st.session_state.get("_dataset_origin") or {}
+    transposed = [i.get("filename") or k for k, i in origins.items()
+                  if i.get("transposed")]
+    if transposed:
+        one = len(transposed) == 1
+        out.append(
+            f"**{'A file was' if one else f'{len(transposed)} files were'} "
+            f"transposed on import** ("
+            + ", ".join(f"`{f}`" for f in transposed[:4])
+            + f"). {'Its' if one else 'Their'} rows and columns were swapped, so "
+              f"what is now a participant was a column in the original file. "
+              f"Check the preview above shows one row per participant."
+        )
+
+    repairs = [(i.get("filename") or k, fx) for k, i in origins.items()
+               for fx in (i.get("repairs") or [])]
+    if repairs:
+        out.append(
+            f"**{len(repairs)} value-level repair(s) were applied at import**, "
+            f"before anything else saw the data: "
+            + "; ".join(f"`{f}` — {fx}" for f, fx in repairs[:4])
+            + ("…" if len(repairs) > 4 else "")
+            + ". These changed values, not counts, so they appear in no "
+              "before/after number on this page."
+        )
 
     return out
 


### PR DESCRIPTION
Upload & Audit explains every decision beautifully **before** you commit to it — the join preview names what will be kept, what will be dropped, and what the merge will do to your n. It had nothing to say **afterwards**, and that asymmetry is what this PR closes.

Three passes, each driven through a browser against a deliberately messy study rather than reasoned about. Every defect below was observed on screen before it was fixed.

## What a researcher saw

A three-file study: 60 enrolled participants, an assay run on 52 of them plus 8 IDs that were never enrolled, and an FFQ with three visits each.

- **The page contradicted itself.** After one cleaning click, the committed join step was still rendering as a live control headlined `156 rows × 10 columns`, directly above `Combined table ready — 156 rows × 9 columns`.
- **The number that matters was never restated.** That 60 people became 52 appeared only inside the join preview, which scrolls away.
- **The cleaning confirmation was a toast.** It survived exactly one interaction, so the account of what had been done to the table was gone by the time you looked away and back.
- **Nothing could be undone.**
- **The page ended on** "Choose an analysis type above to continue."

## What's there now

`utils/table_ledger.py` keeps the account. Every action that reshapes the table records a step, **measured from the two frames** rather than reported by the caller — trusting a caller's numbers is how `record_cleaning(0, 0)` once overwrote a study N with zero. Steps carry **subjects as well as rows**, because a repeated-measures join multiplies rows while people stay flat, and "156" is the wrong answer to how big the study is.

Three surfaces read it:

- **A card at the head of the audit** — what is being audited, what it cost to get there, and every step in order with an **undo** where the frame was small enough to keep a copy. Where it wasn't, the step still appears and the refusal is stated rather than hidden.
- **A sign-off before Step 4** — restates the table and names what a researcher would want to have noticed: *"Your n is 52, not 156"*, *"8 of the 60 people you started with (13%) are not in this table"*, which columns are gone. Ticking it records the shape it was agreed at; any later change withdraws it rather than leaving a stale tick beside moved numbers. It sits above the `st.stop()` that gates Step 4, because the researcher who hasn't chosen an analysis type yet is exactly the one who needs it.
- **The committed combine step collapses** to a summary with a button to reopen, so it stops competing with the table it produced.

## The change that hides best

Stacking two survey cycles that share most but not all of their columns: nothing is empty, nothing is dropped, the row count rises exactly as promised — and `vitamin_d` is missing for all 280 rows from one cycle, `crp` for all 300 from the other. The page's verdict on that table was **"Nothing about this table looks surprising."**

The old check only caught columns that were *entirely* empty, which a stack never produces. It now asks the question that matters — is this column wholly absent from at least one contributing file? — and names the columns, the files, and the counts.

Two more choices that show up in **no before/after number** now reach the sign-off: a **transpose** inverts the table outright, and an Import Doctor **recode** rewrites values while leaving the shape untouched.

## Letting go of the table

Five sites dropped the working table; three left its account standing. `Change Merge Setup` was worst — the next combine appended a second `Combined N files` step to a ledger still describing the first, giving a lineage whose before/after chain didn't join up. All five route through one helper now, and a test fails if a sixth ever pops the table directly.

`Remove` discards the combined table — correctly, since it was built from a set of files that no longer exists — but on one unlabeled click. It says so now, before and after.

## Defects I introduced and then caught

Worth stating plainly, since two of the three passes existed to find them:

- The undo button imported `utils.state_reconciler` for `utils.state_reconcile`. Eighteen tests passed; clicking Undo in a browser did **nothing**. I had tested the ledger's undo thoroughly and never executed the handler that calls it. There's now a test that does.
- Import Doctor repairs never reached the account: the lookup asked by dataset id, filename and name, but the Doctor keys its work by the upload slot (`demographics_csv_0`), so nothing ever matched. `_commit_dataset` now takes the file key — the last moment the two identities coexist.
- The repeated-measures note fired on a mean, producing "each person contributes about 1.0 rows". It now asks whether repetition is *systematic*, and says the right one of two different things.

## Verification

- **Suite: 1349 passed, 4 skipped, 0 failed.**
- **30 new tests.** The ones asserting page structure fail against the pre-change page; the undo-handler test fails against the typo; the stacking test fails against the old empty-column check.
- Driven in a browser across four paths: multi-file join, single file, stacking, and a cleaning action with its undo (10 → 9 → 10 columns, announced, `site` restored, no exception). Nine pages render with no exception.

## Scope

No `ml/`, `models/`, or `data_processor` changes — this is disclosure and UI. The only behavioral change outside page 01 is that `render_combined_summary` no longer restates the shape (the card is now the single place that answers "what have I got"), and `session_manager` persists the ledger so a restored session keeps the account of how its table was built.

**Note:** `claude/tabular-ml-lab-review-nashh7-audit-fixes` is still on the remote and is fully merged via #145 — safe to delete whenever convenient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Y6pZssF946f2jqcuoYKkz

---
_Generated by [Claude Code](https://claude.ai/code/session_016Y6pZssF946f2jqcuoYKkz)_