### PR TITLE
Keep the three files that existed only on university-docker

### DIFF
--- a/docs/deployment-attic/README.md
+++ b/docs/deployment-attic/README.md
@@ -1,0 +1,65 @@
+# Deployment attic
+
+Three files rescued from the `university-docker` branch before it was deleted.
+
+They are here because they existed on that branch and **nowhere else** — not on
+`main`, not on `TurboTab`, not on the branch that folded the Docker layer into
+`main`. Deleting the branch would have been the only copy gone. They are kept as
+reference material, not as code: nothing in the app imports any of them, and
+nothing here is on an import path.
+
+Each is byte-identical to the blob it came from.
+
+---
+
+## `auth.py`
+
+`utils/auth.py` on `university-docker`, 112 lines. Reads `X-Remote-User`,
+`X-Remote-Email` and `X-Remote-Name` off `st.context.headers` and renders a
+"signed in as…" sidebar badge. Written for Shibboleth / CAS / Keycloak / Azure AD
+sitting in front of the app as a reverse proxy.
+
+**It was never wired up.** A grep across every `.py` on that branch finds no
+importer of `utils.auth`, `get_auth_mode`, `get_current_user`, or
+`render_user_badge`. That mattered, because the same branch's `docker-compose.yml`
+and `.env.example` advertised `AUTH_MODE=proxy` and four `AUTH_*` header
+variables — so an administrator could set them, deploy on a campus network, and
+believe the app was gated while the port was open to anyone who could reach it.
+The fold-into-main removed those variables rather than leave them to mislead.
+
+Keep this if you ever want the badge. It is a reasonable starting template — the
+proxy is what does the authenticating either way; this only displays who the
+proxy said you are. It is not, and never was, an access control.
+
+## `compute_config.py`
+
+`utils/compute_config.py` on `university-docker`, 117 lines. A `ComputeProfile`
+dataclass and a `PROFILES` registry — `standard`, `high_performance`,
+`enterprise` — carrying hardware-aware caps for SHAP background and evaluation
+size, permutation repeats, PDP grid resolution, stability bootstrap, RFE CV
+folds, Optuna trials, bootstrap resamples, CV folds, NN max epochs, sensitivity
+seeds and dropout repeats.
+
+Also never imported. `COMPUTE_PROFILE` was documented in three places and read by
+none. It is a coherent piece of design rather than junk, which is why it is here:
+if the app ever needs to scale its expensive analyses to the machine it is on,
+this is the shape that work already took once.
+
+## `deploy.yml`
+
+`.github/workflows/deploy.yml` on `university-docker`, 27 lines. A self-hosted
+runner deploy for a `clawserver` label.
+
+**It never ran, and could not have.** It triggers on push to `main` but existed
+only on `university-docker`, and GitHub resolves workflow files from the ref that
+was pushed. Kept purely as the last record of the production host's operational
+details, which exist in no other ref:
+
+- server path — `/home/claw/.openclaw/workspace/glucose-mlp-interactive`
+- systemd unit — `tabular-ml-lab`
+- the TeX package set the manuscript PDF needs — `texlive-latex-base`,
+  `texlive-latex-recommended`, `texlive-fonts-recommended`, `texlive-latex-extra`
+
+That last line is the one worth keeping. `ci.yml` on `main` installs the same
+four packages so CI compiles the manuscript the live server does; if the server
+is ever rebuilt, this is the list.

--- a/docs/deployment-attic/auth.py
+++ b/docs/deployment-attic/auth.py
@@ -1,0 +1,112 @@
+"""
+User identity from reverse proxy headers.
+
+Authentication must be enforced at the infrastructure layer — a reverse proxy
+(Shibboleth, CAS, KeyCloak, Azure AD App Proxy, OAuth2 Proxy, nginx auth_request)
+that gates ALL traffic before it reaches Streamlit.
+
+This module only reads the authenticated user's identity from forwarded headers
+for display purposes (sidebar badge). It never handles credentials or login flows.
+
+Configuration via environment variables:
+  AUTH_MODE          = disabled | proxy     (default: disabled)
+  AUTH_HEADER        = X-Remote-User        (username header from proxy)
+  AUTH_EMAIL_HEADER  = X-Remote-Email       (email header, optional)
+  AUTH_NAME_HEADER   = X-Remote-Name        (display name header, optional)
+  AUTH_LOGOUT_URL    = https://...          (redirect URL for logout, optional)
+"""
+import os
+import logging
+from dataclasses import dataclass
+from typing import Optional
+
+import streamlit as st
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class UserInfo:
+    """Authenticated user identity."""
+    username: str
+    email: Optional[str] = None
+    display_name: Optional[str] = None
+
+    @property
+    def label(self) -> str:
+        """Best available display string."""
+        return self.display_name or self.email or self.username
+
+
+def get_auth_mode() -> str:
+    """Return configured auth mode from environment."""
+    return os.environ.get("AUTH_MODE", "disabled").lower().strip()
+
+
+def get_current_user() -> Optional[UserInfo]:
+    """Return the current authenticated user, or None if auth is disabled.
+
+    Reads identity from HTTP headers set by the reverse proxy.
+    Uses st.context.headers (Streamlit 1.44+) for header access.
+    """
+    mode = get_auth_mode()
+
+    if mode == "disabled":
+        return None
+
+    if mode == "proxy":
+        return _get_user_from_proxy_headers()
+
+    logger.warning(f"Unknown AUTH_MODE: {mode!r} — treating as disabled")
+    return None
+
+
+def _get_user_from_proxy_headers() -> Optional[UserInfo]:
+    """Read user identity from reverse proxy headers.
+
+    Works with any proxy that sets headers after authentication:
+    Shibboleth, CAS, KeyCloak (as proxy), Azure AD App Proxy, nginx auth_request.
+    """
+    header_key = os.environ.get("AUTH_HEADER", "X-Remote-User")
+    email_key = os.environ.get("AUTH_EMAIL_HEADER", "X-Remote-Email")
+    name_key = os.environ.get("AUTH_NAME_HEADER", "X-Remote-Name")
+
+    try:
+        headers = st.context.headers
+    except Exception:
+        logger.debug("st.context.headers unavailable — auth check skipped")
+        return None
+
+    username = headers.get(header_key)
+    if not username:
+        return None
+
+    return UserInfo(
+        username=username.strip(),
+        email=(headers.get(email_key) or "").strip() or None,
+        display_name=(headers.get(name_key) or "").strip() or None,
+    )
+
+
+def render_user_badge():
+    """Show the authenticated user's identity in the sidebar.
+
+    Reads from reverse proxy headers. No-op when AUTH_MODE=disabled
+    or when running without a proxy.
+    """
+    mode = get_auth_mode()
+    if mode == "disabled":
+        return
+
+    user = get_current_user()
+    if user is None:
+        return
+
+    logout_url = os.environ.get("AUTH_LOGOUT_URL", "").strip()
+
+    with st.sidebar:
+        st.markdown(f"**{user.label}**")
+        if user.email:
+            st.caption(user.email)
+        if logout_url:
+            st.markdown(f"[Logout]({logout_url})")

--- a/docs/deployment-attic/compute_config.py
+++ b/docs/deployment-attic/compute_config.py
@@ -1,0 +1,117 @@
+"""
+Compute profile configuration for institutional deployment.
+
+Provides hardware-aware defaults for compute-intensive operations so that
+university admins can tune the app for their infrastructure without modifying
+application code.
+
+Profiles:
+  standard         — Typical university VM (4-8 GB RAM, no GPU)
+  high_performance — Departmental server (16-32 GB RAM, optional GPU)
+  enterprise       — Research cluster (64+ GB RAM, GPU)
+
+Configuration via environment variable:
+  COMPUTE_PROFILE = standard | high_performance | enterprise
+
+Usage in page code:
+  from utils.compute_config import get_limit
+  shap_bg = get_limit("shap_background")  # returns profile-appropriate value
+"""
+import os
+import logging
+from dataclasses import dataclass, field
+from typing import Dict, Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ComputeProfile:
+    """Hardware-aware limits for compute-intensive operations."""
+    name: str
+    description: str
+    limits: Dict[str, int] = field(default_factory=dict)
+
+
+# ── Profile Definitions ──────────────────────────────────────────
+
+PROFILES: Dict[str, ComputeProfile] = {
+    "standard": ComputeProfile(
+        name="standard",
+        description="University VM (4-8 GB RAM, no GPU)",
+        limits={
+            # Explainability
+            "shap_background": 50,
+            "shap_eval_size": 100,
+            "perm_repeats": 5,
+            "pdp_grid_resolution": 20,
+            # Feature selection
+            "stability_bootstrap": 50,
+            "rfe_cv_folds": 3,
+            # Training
+            "optuna_trials": 15,
+            "bootstrap_resamples": 500,
+            "cv_folds": 5,
+            "nn_max_epochs": 100,
+            # Sensitivity
+            "sensitivity_seeds": 5,
+            "dropout_repeats": 3,
+        },
+    ),
+    "high_performance": ComputeProfile(
+        name="high_performance",
+        description="Departmental server (16-32 GB RAM, optional GPU)",
+        limits={
+            "shap_background": 100,
+            "shap_eval_size": 200,
+            "perm_repeats": 10,
+            "pdp_grid_resolution": 50,
+            "stability_bootstrap": 100,
+            "rfe_cv_folds": 5,
+            "optuna_trials": 30,
+            "bootstrap_resamples": 1000,
+            "cv_folds": 5,
+            "nn_max_epochs": 200,
+            "sensitivity_seeds": 10,
+            "dropout_repeats": 5,
+        },
+    ),
+    "enterprise": ComputeProfile(
+        name="enterprise",
+        description="Research cluster (64+ GB RAM, GPU)",
+        limits={
+            "shap_background": 200,
+            "shap_eval_size": 500,
+            "perm_repeats": 20,
+            "pdp_grid_resolution": 100,
+            "stability_bootstrap": 200,
+            "rfe_cv_folds": 10,
+            "optuna_trials": 100,
+            "bootstrap_resamples": 2000,
+            "cv_folds": 10,
+            "nn_max_epochs": 500,
+            "sensitivity_seeds": 20,
+            "dropout_repeats": 10,
+        },
+    ),
+}
+
+
+def get_profile() -> ComputeProfile:
+    """Return the active compute profile from environment."""
+    name = os.environ.get("COMPUTE_PROFILE", "high_performance").lower().strip()
+    profile = PROFILES.get(name)
+    if profile is None:
+        logger.warning(f"Unknown COMPUTE_PROFILE={name!r}, falling back to high_performance")
+        profile = PROFILES["high_performance"]
+    return profile
+
+
+def get_limit(key: str, default: int = 0) -> int:
+    """Return a specific compute limit from the active profile.
+
+    Usage:
+        from utils.compute_config import get_limit
+        n_repeats = get_limit("perm_repeats", default=10)
+    """
+    return get_profile().limits.get(key, default)

--- a/docs/deployment-attic/deploy.yml
+++ b/docs/deployment-attic/deploy.yml
@@ -1,0 +1,27 @@
+name: Deploy Tabular ML Lab
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: [self-hosted, clawserver]
+    steps:
+      - name: Pull latest code
+        run: |
+          cd /home/claw/.openclaw/workspace/glucose-mlp-interactive
+          git pull origin main
+
+      - name: Install LaTeX (for PDF compilation)
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq texlive-latex-base texlive-latex-recommended texlive-fonts-recommended texlive-latex-extra
+
+      - name: Update dependencies
+        run: |
+          cd /home/claw/.openclaw/workspace/glucose-mlp-interactive
+          ./venv/bin/pip install -r requirements.txt
+
+      - name: Restart service
+        run: |
+          sudo systemctl restart tabular-ml-lab


### PR DESCRIPTION
`university-docker` has been retired. Five of its deployment files came onto main with #148. Three did not, and they existed on no other ref — deleting the branch would have been the only copy gone.

Preserved byte-identical under `docs/deployment-attic/`, with a README explaining what each one is and why none of them was ever wired up:

- **`auth.py`** — reads proxy identity headers and renders a "signed in as" badge. Imported by nothing, which is why the old compose file could advertise `AUTH_MODE=proxy` while the port stayed open to anyone who could reach it. Useful as a template if you ever want the badge; it is not, and never was, access control.
- **`compute_config.py`** — a `ComputeProfile` registry of hardware-aware tuning caps. Documented in three places, read in none.
- **`deploy.yml`** — triggered on push to main but lived only on `university-docker`, and GitHub resolves workflows from the pushed ref, so it never fired. Kept for the production host path, the systemd unit name, and the TeX package set the manuscript PDF needs — the last of which exists in no other ref.

None of it is on an import path, so this adds no runtime surface. Merge and delete the branch.